### PR TITLE
Scaffold 7 crate skeletons (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ fmt:
 fmt-check:
 	cargo fmt --all --check
 
-# Run Clippy for linting. `-D warnings` is the CLAUDE.md bar.
+# Run Clippy for linting. `-D warnings` is the project bar.
 .PHONY: lint
 lint:
 	cargo clippy --all-targets -- -D warnings
@@ -53,7 +53,7 @@ lint-fix:
 clean:
 	cargo clean
 
-# Pre-commit / CI gate per CLAUDE.md: fmt-check + clippy + nextest + release.
+# Pre-commit / CI gate: fmt-check + clippy + nextest + release.
 .PHONY: check
 check: fmt-check lint test release
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,214 @@
+# Makefile for common tasks in the hft-clob-core workspace.
+# Mirrors the OrderBook-rs Makefile layout so muscle memory transfers.
+
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+ZIP_NAME       = hft-clob-core.zip
+
+# Default target
+.PHONY: all
+all: test fmt lint release
+
+# Build the project
+.PHONY: build
+build:
+	cargo build --workspace
+
+.PHONY: release
+release:
+	cargo build --release --workspace
+
+# Run tests via nextest (preferred by CLAUDE.md over `cargo test`).
+# `--no-tests=pass` tolerates empty crates during early bring-up;
+# remove once every crate carries at least one test.
+.PHONY: test
+test: check-cargo-nextest
+	RUST_LOG=warn cargo nextest run --workspace --no-tests=pass
+
+# Plain `cargo test` fallback for machines without nextest installed.
+.PHONY: test-std
+test-std:
+	RUST_LOG=warn cargo test --workspace
+
+# Format the code
+.PHONY: fmt
+fmt:
+	cargo fmt --all
+
+# Check formatting (read-only — CI gate).
+.PHONY: fmt-check
+fmt-check:
+	cargo fmt --all --check
+
+# Run Clippy for linting. `-D warnings` is the CLAUDE.md bar.
+.PHONY: lint
+lint:
+	cargo clippy --all-targets -- -D warnings
+
+.PHONY: lint-fix
+lint-fix:
+	cargo clippy --fix --all-targets --allow-dirty --allow-staged -- -D warnings
+
+# Clean the project
+.PHONY: clean
+clean:
+	cargo clean
+
+# Pre-commit / CI gate per CLAUDE.md: fmt-check + clippy + nextest + release.
+.PHONY: check
+check: fmt-check lint test release
+
+# Run the engine binary (once crates/engine has a [[bin]] target — issue #12/#16).
+.PHONY: run
+run:
+	cargo run --release --bin engine
+
+# Run the replay binary (issue #16).
+.PHONY: replay
+replay:
+	cargo run --release --bin replay -- fixtures/inbound.bin /tmp/outbound.bin --no-timestamps
+
+.PHONY: fix
+fix:
+	cargo fix --workspace --allow-staged --allow-dirty
+
+# Full pre-push: apply fixes, format, lint-fix, run tests, release build, doc check.
+.PHONY: pre-push
+pre-push: fix fmt lint-fix test release doc
+
+# Lint for missing docs on public items (lightweight `cargo doc` proxy).
+.PHONY: doc
+doc:
+	cargo clippy --all-targets -- -W missing-docs
+
+.PHONY: doc-open
+doc-open:
+	cargo doc --workspace --no-deps --open
+
+.PHONY: create-doc
+create-doc:
+	cargo doc --workspace --no-deps --document-private-items
+
+# Coverage via cargo-tarpaulin. Excludes benches and generated files.
+.PHONY: coverage
+coverage: check-cargo-tarpaulin
+	mkdir -p coverage
+	RUST_LOG=warn cargo tarpaulin \
+		--workspace --all-features --timeout 120 \
+		--exclude-files 'crates/*/benches/**' \
+		--exclude-files 'target/**' \
+		--out Xml
+
+.PHONY: coverage-html
+coverage-html: check-cargo-tarpaulin
+	mkdir -p coverage
+	RUST_LOG=warn cargo tarpaulin \
+		--workspace --all-features --timeout 120 \
+		--exclude-files 'crates/*/benches/**' \
+		--exclude-files 'target/**' \
+		--verbose --out Html --output-dir coverage
+
+.PHONY: coverage-json
+coverage-json: check-cargo-tarpaulin
+	mkdir -p coverage
+	RUST_LOG=warn cargo tarpaulin \
+		--workspace --all-features --timeout 120 \
+		--exclude-files 'crates/*/benches/**' \
+		--exclude-files 'target/**' \
+		--verbose --out Json --output-dir coverage
+
+.PHONY: open-coverage
+open-coverage:
+	open coverage/tarpaulin-report.html
+
+# Benchmarks via cargo-criterion. HDR histogram reporting lives inside
+# each bench binary — see BENCH.md for methodology.
+.PHONY: bench
+bench: check-cargo-criterion
+	cargo criterion --workspace --output-format=quiet
+
+.PHONY: bench-show
+bench-show:
+	open target/criterion/reports/index.html
+
+.PHONY: bench-save
+bench-save: check-cargo-criterion
+	cargo criterion --workspace --output-format=quiet \
+		--history-id v0.1.0 --history-description "First tagged run"
+
+.PHONY: bench-compare
+bench-compare: check-cargo-criterion
+	cargo criterion --workspace --output-format=verbose
+
+.PHONY: bench-json
+bench-json: check-cargo-criterion
+	cargo criterion --workspace --message-format=json
+
+.PHONY: bench-clean
+bench-clean:
+	rm -rf target/criterion
+
+# Git log for the current branch vs main.
+.PHONY: git-log
+git-log:
+	@if [ "$(CURRENT_BRANCH)" = "HEAD" ]; then \
+		echo "You are in a detached HEAD state. Please check out a branch."; \
+		exit 1; \
+	fi; \
+	echo "Showing git log for branch $(CURRENT_BRANCH) against main:"; \
+	git log main..$(CURRENT_BRANCH) --pretty=full
+
+# Package repo as a zip for offline review.
+.PHONY: zip
+zip:
+	@echo "Creating $(ZIP_NAME) without target/, Cargo.lock, and hidden files..."
+	@find . -type f \
+		! -path "*/target/*" \
+		! -path "./.*" \
+		! -name "Cargo.lock" \
+		! -name ".*" \
+		| zip -@ $(ZIP_NAME)
+	@echo "$(ZIP_NAME) created successfully."
+
+# Run GitHub Actions locally via `act`. Requires DOCKER_HOST to be set.
+.PHONY: workflow-build
+workflow-build:
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job build \
+		-P ubuntu-latest=catthehacker/ubuntu:latest
+
+.PHONY: workflow-lint
+workflow-lint:
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job lint \
+		-P ubuntu-latest=catthehacker/ubuntu:latest
+
+.PHONY: workflow-test
+workflow-test:
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job test \
+		-P ubuntu-latest=catthehacker/ubuntu:latest
+
+.PHONY: workflow-coverage
+workflow-coverage:
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job coverage \
+		-P ubuntu-latest=catthehacker/ubuntu:latest \
+		--privileged
+
+.PHONY: workflow
+workflow: workflow-build workflow-lint workflow-test workflow-coverage
+
+# Tree view of the workspace, skipping generated / vendored content.
+.PHONY: tree
+tree:
+	tree -I 'target|.idea|.run|.DS_Store|Cargo.lock|*.zip|*.html|*.xml|*.json|*.bin|coverage|fixtures' -a -L 3
+
+# --- tool presence helpers ------------------------------------------------
+
+.PHONY: check-cargo-nextest
+check-cargo-nextest:
+	@command -v cargo-nextest > /dev/null || (echo "Installing cargo-nextest..."; cargo install cargo-nextest --locked)
+
+.PHONY: check-cargo-tarpaulin
+check-cargo-tarpaulin:
+	@command -v cargo-tarpaulin > /dev/null || (echo "Installing cargo-tarpaulin..."; cargo install cargo-tarpaulin --locked)
+
+.PHONY: check-cargo-criterion
+check-cargo-criterion:
+	@command -v cargo-criterion > /dev/null || (echo "Installing cargo-criterion..."; cargo install cargo-criterion --locked)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 release:
 	cargo build --release --workspace
 
-# Run tests via nextest (preferred by CLAUDE.md over `cargo test`).
+# Run tests via nextest (preferred by matching codebase over `cargo test`).
 # `--no-tests=pass` tolerates empty crates during early bring-up;
 # remove once every crate carries at least one test.
 .PHONY: test
@@ -118,17 +118,23 @@ coverage-json: check-cargo-tarpaulin
 
 .PHONY: open-coverage
 open-coverage:
-	open coverage/tarpaulin-report.html
+	@if [ -f coverage/tarpaulin-report.html ]; then \
+		if command -v open > /dev/null; then open coverage/tarpaulin-report.html; \
+		else echo "Open coverage/tarpaulin-report.html in your browser"; fi; \
+	else echo "coverage/tarpaulin-report.html not found. Run 'make coverage' first."; fi
 
 # Benchmarks via cargo-criterion. HDR histogram reporting lives inside
-# each bench binary — see BENCH.md for methodology.
+# each bench binary — detailed methodology documented in BENCH.md (issue #17).
 .PHONY: bench
 bench: check-cargo-criterion
 	cargo criterion --workspace --output-format=quiet
 
 .PHONY: bench-show
 bench-show:
-	open target/criterion/reports/index.html
+	@if [ -f target/criterion/reports/index.html ]; then \
+		if command -v open > /dev/null; then open target/criterion/reports/index.html; \
+		else echo "Open target/criterion/reports/index.html in your browser"; fi; \
+	else echo "target/criterion/reports/index.html not found. Run 'make bench' first."; fi
 
 .PHONY: bench-save
 bench-save: check-cargo-criterion

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "domain"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,0 +1,12 @@
+//! Core domain types and invariants.
+//!
+//! Pure types and value objects for the matching engine. No I/O, no async,
+//! no wall-clock. This crate depends on nothing and is depended on by all
+//! other crates in the workspace.
+//!
+//! Invariants:
+//! - All prices and quantities are represented as fixed-point scaled `i64`.
+//!   No `f32` or `f64` anywhere.
+//! - Named constants for tick size and lot size; no magic numbers.
+//! - Domain newtypes (`Price`, `Qty`, `OrderId`, `AccountId`, `EngineSeq`,
+//!   `ClientTs`, `RecvTs`) enforce type safety at boundaries.

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "engine"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+wire = { workspace = true }
+matching = { workspace = true }
+risk = { workspace = true }
+marketdata = { workspace = true }
+gateway = { workspace = true }
+ironsbe-channel = { workspace = true }
+parking_lot.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+criterion = { workspace = true, features = ["html_reports"] }
+hdrhistogram.workspace = true

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,0 +1,12 @@
+//! Engine — single-writer matching pipeline.
+//!
+//! Wires together gateway, matching, risk, and marketdata into a coherent
+//! single-writer event loop. The engine thread is the sole mutator of the
+//! order book; no other thread touches it.
+//!
+//! Also defines the `Clock` and `IdGenerator` traits for deterministic
+//! replay: during normal operation, these are backed by `SystemTime` and
+//! `ulid`; during replay, they delegate to monotonic counter stubs so that
+//! outputs are byte-identical across runs.
+//!
+//! **No tokio here.** The engine is pure blocking and pinnable to a CPU core.

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "gateway"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+wire = { workspace = true }
+tokio = { workspace = true, features = ["rt", "io-util", "net", "macros", "time"] }
+ironsbe-transport = { workspace = true }
+ironsbe-server = { workspace = true }
+ironsbe-channel = { workspace = true }
+ironsbe-core = { workspace = true }
+bytes.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -1,0 +1,8 @@
+//! Gateway — wire protocol parsing and session management.
+//!
+//! Listens on TCP for inbound order-entry messages, decodes them using
+//! the binary wire protocol, and forwards `Command` to the matching engine
+//! via SPSC ring buffer. Also handles graceful shutdown and session bookkeeping.
+//!
+//! **Only crate in the workspace that uses tokio and async.** All other
+//! crates remain pure blocking and deterministic.

--- a/crates/marketdata/Cargo.toml
+++ b/crates/marketdata/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "marketdata"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+wire = { workspace = true }
+ironsbe-channel = { workspace = true }
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/marketdata/src/lib.rs
+++ b/crates/marketdata/src/lib.rs
@@ -1,0 +1,8 @@
+//! Outbound stream emission — market data and execution reports.
+//!
+//! Consumes `OutEvent` from the matching core and encodes them into
+//! on-wire messages: trade prints, top-of-book updates, and execution reports.
+//! Emits to TCP or file via the outbound channel.
+//!
+//! Maintains `engine_seq` consistency and gap-detection hooks for packet loss.
+//! L2 incremental snapshot + delta recovery is a stretch goal.

--- a/crates/matching/Cargo.toml
+++ b/crates/matching/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "matching"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+pricelevel = { workspace = true }
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -1,0 +1,15 @@
+//! Single-writer matching core.
+//!
+//! The hot path of the system. Consumes `Command` from the gateway,
+//! applies risk checks, matches orders against the book using price-time
+//! priority, and emits `OutEvent` to the outbound stream.
+//!
+//! Invariants enforced:
+//! - No wall-clock reads (no `SystemTime`, `Instant::now`). Timestamps
+//!   enter via injected `Clock` trait for deterministic replay.
+//! - No randomness (no `rand::*`). ID generation via injected `IdGenerator`.
+//! - No unordered iteration into outputs. Book index is `BTreeMap<Price, _>`
+//!   sorted by price; iteration order is deterministic.
+//! - `engine_seq` is strictly monotonic across all outbound events.
+//!   Checked arithmetic on every increment.
+//! - No tokio, no async. Pure blocking single-writer thread.

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -1,8 +1,8 @@
 //! Single-writer matching core.
 //!
-//! The hot path of the system. Consumes `Command` from the gateway,
-//! applies risk checks, matches orders against the book using price-time
-//! priority, and emits `OutEvent` to the outbound stream.
+//! The hot path of the system. Consumes orders that have passed risk validation,
+//! matches them against the book using price-time priority, and emits
+//! `OutEvent` to the outbound stream.
 //!
 //! Invariants enforced:
 //! - No wall-clock reads (no `SystemTime`, `Instant::now`). Timestamps

--- a/crates/risk/Cargo.toml
+++ b/crates/risk/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "risk"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -1,0 +1,9 @@
+//! Risk and operational controls.
+//!
+//! Pre-trade and in-trade checks: kill switch, per-account max order count,
+//! per-account max notional exposure, price band / fat-finger check,
+//! self-trade prevention (cancel-both policy), and rejection reason codes.
+//!
+//! These checks are invoked before matching steps. The kill switch is
+//! observed at the engine level so that outstanding orders are not matched
+//! or emitted after the kill is engaged.

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "wire"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+domain = { workspace = true }
+ironsbe-core = { workspace = true }
+ironsbe-derive = { workspace = true }
+bytes.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -1,0 +1,8 @@
+//! Binary wire protocol — SBE-based schema, encoders, decoders.
+//!
+//! Defines the on-wire message format for order entry (inbound) and
+//! market data / execution reports (outbound). Uses IronSBE for zero-copy
+//! schema and code generation. All lengths are little-endian; framing is
+//! length-prefixed TCP (first 4 bytes = message length in bytes).
+//!
+//! Roundtrip tests verify encode → decode preserves all fields byte-identically.

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -5,4 +5,4 @@
 //! schema and code generation. All lengths are little-endian; framing is
 //! length-prefixed TCP (first 4 bytes = message length in bytes).
 //!
-//! Roundtrip tests verify encode → decode preserves all fields byte-identically.
+//! Roundtrip tests will verify encode → decode preserves all fields byte-identically (issue #5).


### PR DESCRIPTION
## Summary

Scaffold the 7 workspace members (`domain`, `wire`, `matching`, `risk`,
`marketdata`, `gateway`, `engine`) with minimal `Cargo.toml` + `src/lib.rs`
stubs, plus a workspace `Makefile` for common dev tasks. Unblocks every
downstream issue.

## Changes

- 14 new crate scaffolding files (2 per crate) + `Makefile` = 15 new files total.
- Each `lib.rs` carries a module-level `//!` doc with the crate's purpose
  and the invariants it enforces.
- `Makefile` exposes `build`, `release`, `fmt`, `fmt-check`, `lint`,
  `lint-fix`, `test` (nextest), `check` (pre-commit gate), `pre-push`,
  `coverage*`, `bench*`, `workflow-*`, `tree`, `zip`. Mirrors the
  `OrderBook-rs` Makefile shape so muscle memory transfers.
- Per-crate dep wiring follows `doc/DESIGN.md` § 2.1.
- `matching` / `risk` / `domain` carry no tokio dependency, direct or
  transitive — verified by inspection of each `Cargo.toml`.
- `gateway` is the only crate depending on `tokio`, `ironsbe-transport`,
  `ironsbe-server`.

## Technical decisions

- Third-party deps (`pricelevel`, `ironsbe-*`) are pinned to the crates.io
  published versions (`pricelevel = "0.7"`, `ironsbe-* = "0.3"`) via
  `[workspace.dependencies]`. This keeps Docker builds and reviewer
  machines working without sibling path repos.
- `engine` declares `parking_lot`, `tracing`, `criterion`, `hdrhistogram`
  up front so downstream issues (bench, replay binary) don't touch the
  scaffold again.
- `wire` declares `bytes` for future buffer plumbing; `thiserror` will be
  added when the `DecodeError` / `EncodeError` enums land in #4 / #5.
- Coverage / bench Makefile targets that open HTML reports detect the
  presence of `open` and fall back to printing the report path on
  Linux / Windows.

## Testing

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run --no-tests=pass` clean (zero tests yet; gate still green)
- [x] `cargo build --release` clean
- [x] `cargo check --workspace` clean

Note on nextest: empty workspaces fail `cargo nextest run` with "no tests
to run". `--no-tests=pass` is the correct flag and should be the default
in CI (#2) until crates have tests. Not a production concern.

## Checklist

- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Integer-only prices/qty not yet introduced (comes with #3)
- [x] No wall-clock reads in `crates/matching/`
- [x] No `HashMap` / `HashSet` / `DashMap` iteration reaches outbound messages
- [x] Every `unsafe` block carries a `// SAFETY:` comment — N/A, no unsafe in this PR
- [x] Module boundaries respected (matching / risk / domain depend downward only; tokio stays in gateway)
- [x] No new dependencies added without an entry under the third-party allowances list
- [x] `tracing` only for logging — no `println!`; matching core has no logging at all

Closes #1