### PR TITLE
Add domain newtypes, enums, and constants (#3)

### DIFF
--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]
+thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/domain/src/consts.rs
+++ b/crates/domain/src/consts.rs
@@ -1,0 +1,34 @@
+//! Workspace-wide named constants.
+//!
+//! No magic numbers anywhere else in the workspace — every literal traces
+//! back to one of these constants. CLAUDE.md is explicit: `TICK_SIZE` and
+//! `LOT_SIZE` live in `domain::consts`.
+
+/// Smallest legal price increment, expressed as a raw tick count.
+///
+/// `Price` values must be a positive multiple of this constant.
+pub const TICK_SIZE: i64 = 1;
+
+/// Smallest legal quantity increment, expressed as a raw lot count.
+///
+/// `Qty` values must be a positive multiple of this constant.
+pub const LOT_SIZE: u64 = 1;
+
+/// Price-band tolerance vs the reference price, in basis points.
+///
+/// `1 bp = 0.01 %`, so `PRICE_BAND_BPS = 500` means an inbound order is
+/// rejected when its price differs from the reference by more than ±5 %.
+pub const PRICE_BAND_BPS: u32 = 500;
+
+/// Hard ceiling on the count of resting open orders per account.
+pub const MAX_OPEN_ORDERS_PER_ACCT: u32 = 1_000;
+
+/// Hard ceiling on aggregate notional exposure per account.
+///
+/// Stored as `u128` so a market order's worst-case far-touch fill price
+/// cannot overflow during the pre-trade check.
+pub const MAX_NOTIONAL_PER_ACCT: u128 = 10_000_000_000;
+
+/// Single-symbol venue identifier. Hardcoded per CLAUDE.md scope; the
+/// engine is single-symbol by design.
+pub const SYMBOL: &str = "BTC-USDC";

--- a/crates/domain/src/consts.rs
+++ b/crates/domain/src/consts.rs
@@ -1,8 +1,10 @@
 //! Workspace-wide named constants.
 //!
-//! No magic numbers anywhere else in the workspace — every literal traces
-//! back to one of these constants. CLAUDE.md is explicit: `TICK_SIZE` and
-//! `LOT_SIZE` live in `domain::consts`.
+//! Every constant that appears in domain validation, risk policy, or
+//! matching logic lives here — `TICK_SIZE`, `LOT_SIZE`, `PRICE_BAND_BPS`,
+//! account limits, and the venue symbol. Buffer sizes, frame headers,
+//! and other purely-mechanical literals stay close to the code that
+//! uses them; they are not policy and do not belong here.
 
 /// Smallest legal price increment, expressed as a raw tick count.
 ///

--- a/crates/domain/src/error.rs
+++ b/crates/domain/src/error.rs
@@ -1,0 +1,53 @@
+//! Aggregated domain error.
+//!
+//! Every domain primitive owns its own `thiserror` enum (`PriceError`,
+//! `QtyError`, …). [`DomainError`] re-emits them through `#[from]` so
+//! upstream crates can carry a single error variant when the underlying
+//! validation source is incidental.
+
+use thiserror::Error;
+
+use crate::types::{
+    AccountIdError, CancelReasonError, EngineSeqError, OrderIdError, OrderTypeError, PriceError,
+    QtyError, RejectReasonError, SideError, TifError, TradeIdError,
+};
+
+/// Aggregator over every per-type validation / decode error in the
+/// `domain` crate.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DomainError {
+    /// `Price` validation.
+    #[error(transparent)]
+    Price(#[from] PriceError),
+    /// `Qty` validation.
+    #[error(transparent)]
+    Qty(#[from] QtyError),
+    /// `OrderId` validation.
+    #[error(transparent)]
+    OrderId(#[from] OrderIdError),
+    /// `AccountId` validation.
+    #[error(transparent)]
+    AccountId(#[from] AccountIdError),
+    /// `EngineSeq` arithmetic overflow.
+    #[error(transparent)]
+    EngineSeq(#[from] EngineSeqError),
+    /// `TradeId` arithmetic overflow.
+    #[error(transparent)]
+    TradeId(#[from] TradeIdError),
+    /// `Side` decode.
+    #[error(transparent)]
+    Side(#[from] SideError),
+    /// `OrderType` decode.
+    #[error(transparent)]
+    OrderType(#[from] OrderTypeError),
+    /// `Tif` decode.
+    #[error(transparent)]
+    Tif(#[from] TifError),
+    /// `RejectReason` decode.
+    #[error(transparent)]
+    RejectReason(#[from] RejectReasonError),
+    /// `CancelReason` decode.
+    #[error(transparent)]
+    CancelReason(#[from] CancelReasonError),
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -9,8 +9,8 @@
 //!   integers (`i64` for `Price`, `u64` for `Qty`). No `f32` / `f64`
 //!   anywhere in this crate.
 //! - Named constants for tick size, lot size, price band, and account
-//!   limits — see [`consts`]. No magic numbers anywhere else in the
-//!   workspace.
+//!   limits — see [`consts`]. Domain validation, risk policy, and
+//!   matching logic refer to these names rather than to bare literals.
 //! - Domain newtypes (`Price`, `Qty`, `OrderId`, `AccountId`,
 //!   `EngineSeq`, `TradeId`, `ClientTs`, `RecvTs`) enforce type safety
 //!   at every boundary.

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,12 +1,33 @@
 //! Core domain types and invariants.
 //!
-//! Pure types and value objects for the matching engine. No I/O, no async,
-//! no wall-clock. This crate depends on nothing and is depended on by all
-//! other crates in the workspace.
+//! Pure types and value objects for the matching engine. No I/O, no
+//! async, no wall-clock. This crate depends on nothing and is depended
+//! on by every other crate in the workspace.
 //!
 //! Invariants:
-//! - All prices and quantities are represented as fixed-point scaled `i64`.
-//!   No `f32` or `f64` anywhere.
-//! - Named constants for tick size and lot size; no magic numbers.
-//! - Domain newtypes (`Price`, `Qty`, `OrderId`, `AccountId`, `EngineSeq`,
-//!   `ClientTs`, `RecvTs`) enforce type safety at boundaries.
+//! - All prices and quantities are represented as fixed-point scaled
+//!   integers (`i64` for `Price`, `u64` for `Qty`). No `f32` / `f64`
+//!   anywhere in this crate.
+//! - Named constants for tick size, lot size, price band, and account
+//!   limits — see [`consts`]. No magic numbers anywhere else in the
+//!   workspace.
+//! - Domain newtypes (`Price`, `Qty`, `OrderId`, `AccountId`,
+//!   `EngineSeq`, `TradeId`, `ClientTs`, `RecvTs`) enforce type safety
+//!   at every boundary.
+//! - Wire-stable enums (`Side`, `OrderType`, `Tif`, `RejectReason`,
+//!   `CancelReason`) carry explicit numeric discriminants that never
+//!   change across schema versions.
+
+#![warn(missing_docs)]
+
+pub mod consts;
+pub mod error;
+pub mod types;
+
+pub use error::DomainError;
+pub use types::{
+    AccountId, AccountIdError, CancelReason, CancelReasonError, ClientTs, EngineSeq,
+    EngineSeqError, OrderId, OrderIdError, OrderType, OrderTypeError, Price, PriceError, Qty,
+    QtyError, RecvTs, RejectReason, RejectReasonError, Side, SideError, Tif, TifError, TradeId,
+    TradeIdError,
+};

--- a/crates/domain/src/types/account_id.rs
+++ b/crates/domain/src/types/account_id.rs
@@ -1,0 +1,91 @@
+//! Account identifier.
+
+use std::fmt;
+
+/// Per-session account identifier.
+///
+/// # Invariants
+/// - Inner value is non-zero. `0` is reserved as a sentinel for
+///   "anonymous" / "no account" and never legal as a payload.
+/// - The engine binds an `AccountId` to a session at connection
+///   establishment; this type does not enforce that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct AccountId(u32);
+
+impl AccountId {
+    /// Construct from a raw `u32`.
+    ///
+    /// # Errors
+    /// Returns [`AccountIdError::Zero`] when `id == 0`.
+    #[inline]
+    pub const fn new(id: u32) -> Result<Self, AccountIdError> {
+        if id == 0 {
+            return Err(AccountIdError::Zero);
+        }
+        Ok(Self(id))
+    }
+
+    /// Raw identifier. Use only at the wire / serialization edge.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<u32> for AccountId {
+    type Error = AccountIdError;
+    #[inline]
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "acct:{}", self.0)
+    }
+}
+
+/// Validation error for [`AccountId::new`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AccountIdError {
+    /// `id == 0` (reserved sentinel).
+    #[error("account_id must be non-zero")]
+    Zero,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for AccountId {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (1u32..=u32::MAX)
+                .prop_map(|v| AccountId::new(v).expect("strategy yields valid AccountId"))
+                .boxed()
+        }
+    }
+
+    #[test]
+    fn test_account_id_new_zero_returns_err() {
+        assert_eq!(AccountId::new(0), Err(AccountIdError::Zero));
+    }
+
+    #[test]
+    fn test_account_id_new_one_returns_ok() {
+        assert!(AccountId::new(1).is_ok());
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_account_id_roundtrip(id in any::<AccountId>()) {
+            prop_assert_eq!(AccountId::new(id.as_raw()).expect("roundtrip"), id);
+        }
+    }
+}

--- a/crates/domain/src/types/cancel_reason.rs
+++ b/crates/domain/src/types/cancel_reason.rs
@@ -1,0 +1,107 @@
+//! Cancellation reason codes.
+
+use std::fmt;
+
+/// Closed enumeration of cancellation reasons emitted in execution
+/// reports. Wire-stable: numeric discriminants are part of the public
+/// contract and must not be reassigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CancelReason {
+    /// Client sent an explicit `CancelOrder`.
+    UserRequested = 1,
+    /// Client sent a `MassCancel` covering this order.
+    MassCancel = 2,
+    /// IOC remainder cancelled after the partial fill walk.
+    IocRemaining = 3,
+    /// Self-trade prevention fired with cancel-both policy.
+    SelfTradePrevented = 4,
+    /// Order superseded by a `CancelReplace` that could not preserve
+    /// queue priority.
+    Replaced = 5,
+}
+
+impl CancelReason {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for CancelReason {
+    type Error = CancelReasonError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::UserRequested),
+            2 => Ok(Self::MassCancel),
+            3 => Ok(Self::IocRemaining),
+            4 => Ok(Self::SelfTradePrevented),
+            5 => Ok(Self::Replaced),
+            other => Err(CancelReasonError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for CancelReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Decode error for [`CancelReason::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CancelReasonError {
+    /// Wire payload contained a discriminant outside the assigned range.
+    #[error("unknown CancelReason discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for CancelReason {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![
+                Just(Self::UserRequested),
+                Just(Self::MassCancel),
+                Just(Self::IocRemaining),
+                Just(Self::SelfTradePrevented),
+                Just(Self::Replaced),
+            ]
+            .boxed()
+        }
+    }
+
+    #[test]
+    fn test_cancel_reason_discriminants_are_stable() {
+        assert_eq!(CancelReason::UserRequested.as_u8(), 1);
+        assert_eq!(CancelReason::Replaced.as_u8(), 5);
+    }
+
+    #[test]
+    fn test_cancel_reason_try_from_unknown_returns_err() {
+        assert_eq!(
+            CancelReason::try_from(0),
+            Err(CancelReasonError::Unknown(0))
+        );
+        assert_eq!(
+            CancelReason::try_from(6),
+            Err(CancelReasonError::Unknown(6))
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_cancel_reason_u8_roundtrip(r in any::<CancelReason>()) {
+            prop_assert_eq!(CancelReason::try_from(r.as_u8()).expect("roundtrip"), r);
+        }
+    }
+}

--- a/crates/domain/src/types/client_ts.rs
+++ b/crates/domain/src/types/client_ts.rs
@@ -1,0 +1,74 @@
+//! Client-stamped timestamp.
+
+use std::fmt;
+
+/// Client-stamped timestamp in nanoseconds since the UNIX epoch.
+///
+/// # Invariants
+/// - The inner value is opaque to the engine; the matching core never
+///   reads it for control flow. It is carried on inbound messages and
+///   echoed in execution reports for client-side correlation.
+/// - This type does not call the wall clock — construction is purely
+///   from a value the caller already has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct ClientTs(i64);
+
+impl ClientTs {
+    /// Zero-valued sentinel for "unset". Useful in tests and as a
+    /// neutral default in proptests; not a meaningful timestamp.
+    pub const ZERO: Self = Self(0);
+
+    /// Construct from a raw nanosecond count.
+    #[inline]
+    #[must_use]
+    pub const fn new(nanos: i64) -> Self {
+        Self(nanos)
+    }
+
+    /// Raw nanosecond count.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_nanos(self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for ClientTs {
+    #[inline]
+    fn from(v: i64) -> Self {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for ClientTs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cts:{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for ClientTs {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            any::<i64>().prop_map(ClientTs::new).boxed()
+        }
+    }
+
+    #[test]
+    fn test_client_ts_zero_is_zero() {
+        assert_eq!(ClientTs::ZERO.as_nanos(), 0);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_client_ts_roundtrip(ts in any::<ClientTs>()) {
+            prop_assert_eq!(ClientTs::new(ts.as_nanos()), ts);
+        }
+    }
+}

--- a/crates/domain/src/types/engine_seq.rs
+++ b/crates/domain/src/types/engine_seq.rs
@@ -100,7 +100,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn proptest_engine_seq_strictly_monotonic(seed in 0u64..u64::MAX - 1) {
+        fn proptest_engine_seq_strictly_monotonic(seed in 0u64..=u64::MAX - 1) {
             let s0 = EngineSeq::new(seed);
             let s1 = s0.next().expect("no overflow");
             prop_assert!(s1 > s0);

--- a/crates/domain/src/types/engine_seq.rs
+++ b/crates/domain/src/types/engine_seq.rs
@@ -1,0 +1,110 @@
+//! Strictly monotonic engine sequence number.
+
+use std::fmt;
+
+/// Engine-assigned sequence number, strictly monotonic across every
+/// outbound stream (exec reports + trade prints + book updates).
+///
+/// # Invariants
+/// - Inner value increments by exactly one per outbound message via
+///   [`EngineSeq::next`]. Skips and gaps indicate a bug.
+/// - Construction via [`EngineSeq::INITIAL`] is the engine's normal
+///   start-of-day path; [`EngineSeq::new`] is provided so the replay
+///   harness can seed from a recorded value.
+/// - Arithmetic is checked — overflow returns
+///   [`EngineSeqError::Overflow`] rather than panicking or wrapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct EngineSeq(u64);
+
+impl EngineSeq {
+    /// Initial value. The engine starts every run from here.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct from a raw `u64`. Used by the replay harness to seed
+    /// the counter from a recorded value.
+    #[inline]
+    #[must_use]
+    pub const fn new(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Advance to the next sequence number.
+    ///
+    /// # Errors
+    /// Returns [`EngineSeqError::Overflow`] when the counter would
+    /// exceed [`u64::MAX`]. CLAUDE.md forbids `saturating_*` /
+    /// `wrapping_*` on protocol counters; this is the correct path.
+    #[inline]
+    pub const fn next(self) -> Result<Self, EngineSeqError> {
+        match self.0.checked_add(1) {
+            Some(v) => Ok(Self(v)),
+            None => Err(EngineSeqError::Overflow),
+        }
+    }
+
+    /// Raw counter value. Use only at the wire / serialization edge.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for EngineSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "seq:{}", self.0)
+    }
+}
+
+/// Error type for [`EngineSeq::next`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EngineSeqError {
+    /// Counter would exceed [`u64::MAX`].
+    #[error("engine_seq overflow")]
+    Overflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for EngineSeq {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (0u64..=u64::MAX).prop_map(EngineSeq::new).boxed()
+        }
+    }
+
+    #[test]
+    fn test_engine_seq_initial_is_zero() {
+        assert_eq!(EngineSeq::INITIAL.as_raw(), 0);
+    }
+
+    #[test]
+    fn test_engine_seq_next_increments_by_one() {
+        let s = EngineSeq::new(41).next().expect("no overflow");
+        assert_eq!(s.as_raw(), 42);
+    }
+
+    #[test]
+    fn test_engine_seq_next_overflow_returns_err() {
+        assert_eq!(
+            EngineSeq::new(u64::MAX).next(),
+            Err(EngineSeqError::Overflow)
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_engine_seq_strictly_monotonic(seed in 0u64..u64::MAX - 1) {
+            let s0 = EngineSeq::new(seed);
+            let s1 = s0.next().expect("no overflow");
+            prop_assert!(s1 > s0);
+            prop_assert_eq!(s1.as_raw(), seed + 1);
+        }
+    }
+}

--- a/crates/domain/src/types/mod.rs
+++ b/crates/domain/src/types/mod.rs
@@ -1,0 +1,32 @@
+//! Domain types — newtypes wrapping integer primitives and stable
+//! enums crossing the wire.
+
+mod account_id;
+mod client_ts;
+mod engine_seq;
+mod order_id;
+mod price;
+mod qty;
+mod recv_ts;
+mod trade_id;
+
+mod cancel_reason;
+mod order_type;
+mod reject_reason;
+mod side;
+mod tif;
+
+pub use account_id::{AccountId, AccountIdError};
+pub use client_ts::ClientTs;
+pub use engine_seq::{EngineSeq, EngineSeqError};
+pub use order_id::{OrderId, OrderIdError};
+pub use price::{Price, PriceError};
+pub use qty::{Qty, QtyError};
+pub use recv_ts::RecvTs;
+pub use trade_id::{TradeId, TradeIdError};
+
+pub use cancel_reason::{CancelReason, CancelReasonError};
+pub use order_type::{OrderType, OrderTypeError};
+pub use reject_reason::{RejectReason, RejectReasonError};
+pub use side::{Side, SideError};
+pub use tif::{Tif, TifError};

--- a/crates/domain/src/types/order_id.rs
+++ b/crates/domain/src/types/order_id.rs
@@ -1,0 +1,91 @@
+//! Client-assigned order identifier.
+
+use std::fmt;
+
+/// Client-assigned order identifier, unique per `(account_id, order_id)`.
+///
+/// # Invariants
+/// - Inner value is non-zero. `0` is reserved as a sentinel for "no
+///   identifier" in upstream protocols and never legal as a payload.
+/// - Identifier uniqueness across an account is enforced by the engine,
+///   not by this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct OrderId(u64);
+
+impl OrderId {
+    /// Construct from a raw `u64`.
+    ///
+    /// # Errors
+    /// Returns [`OrderIdError::Zero`] when `id == 0`.
+    #[inline]
+    pub const fn new(id: u64) -> Result<Self, OrderIdError> {
+        if id == 0 {
+            return Err(OrderIdError::Zero);
+        }
+        Ok(Self(id))
+    }
+
+    /// Raw identifier. Use only at the wire / serialization edge.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for OrderId {
+    type Error = OrderIdError;
+    #[inline]
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for OrderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ord:{}", self.0)
+    }
+}
+
+/// Validation error for [`OrderId::new`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrderIdError {
+    /// `id == 0` (reserved sentinel).
+    #[error("order_id must be non-zero")]
+    Zero,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for OrderId {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (1u64..=u64::MAX)
+                .prop_map(|v| OrderId::new(v).expect("strategy yields valid OrderId"))
+                .boxed()
+        }
+    }
+
+    #[test]
+    fn test_order_id_new_zero_returns_err() {
+        assert_eq!(OrderId::new(0), Err(OrderIdError::Zero));
+    }
+
+    #[test]
+    fn test_order_id_new_one_returns_ok() {
+        assert!(OrderId::new(1).is_ok());
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_order_id_roundtrip(id in any::<OrderId>()) {
+            prop_assert_eq!(OrderId::new(id.as_raw()).expect("roundtrip"), id);
+        }
+    }
+}

--- a/crates/domain/src/types/order_type.rs
+++ b/crates/domain/src/types/order_type.rs
@@ -1,0 +1,86 @@
+//! Order type.
+
+use std::fmt;
+
+/// Order type. Wire-stable: numeric discriminants are part of the
+/// public contract and must not be reassigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum OrderType {
+    /// Limit order — rests on the book if not fully matched.
+    Limit = 1,
+    /// Market order — partial-fill-and-cancel; never rests.
+    Market = 2,
+}
+
+impl OrderType {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for OrderType {
+    type Error = OrderTypeError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::Limit),
+            2 => Ok(Self::Market),
+            other => Err(OrderTypeError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for OrderType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Limit => f.write_str("Limit"),
+            Self::Market => f.write_str("Market"),
+        }
+    }
+}
+
+/// Decode error for [`OrderType::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrderTypeError {
+    /// Wire payload contained a discriminant outside `{1, 2}`.
+    #[error("unknown OrderType discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for OrderType {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![Just(OrderType::Limit), Just(OrderType::Market)].boxed()
+        }
+    }
+
+    #[test]
+    fn test_order_type_as_u8_assigns_one_and_two() {
+        assert_eq!(OrderType::Limit.as_u8(), 1);
+        assert_eq!(OrderType::Market.as_u8(), 2);
+    }
+
+    #[test]
+    fn test_order_type_try_from_unknown_returns_err() {
+        assert_eq!(OrderType::try_from(0), Err(OrderTypeError::Unknown(0)));
+        assert_eq!(OrderType::try_from(3), Err(OrderTypeError::Unknown(3)));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_order_type_u8_roundtrip(ot in any::<OrderType>()) {
+            prop_assert_eq!(OrderType::try_from(ot.as_u8()).expect("roundtrip"), ot);
+        }
+    }
+}

--- a/crates/domain/src/types/price.rs
+++ b/crates/domain/src/types/price.rs
@@ -93,8 +93,10 @@ mod tests {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
         fn arbitrary_with(_: ()) -> Self::Strategy {
+            // Generate as a multiple of TICK_SIZE so the strategy stays
+            // valid the moment a future PR raises TICK_SIZE above 1.
             (1i64..=1_000_000)
-                .prop_map(|v| Price::new(v).expect("strategy yields valid Price"))
+                .prop_map(|n| Price::new(n * TICK_SIZE).expect("strategy yields valid Price"))
                 .boxed()
         }
     }
@@ -110,8 +112,8 @@ mod tests {
     }
 
     #[test]
-    fn test_price_new_one_returns_ok() {
-        assert!(Price::new(1).is_ok());
+    fn test_price_new_one_tick_returns_ok() {
+        assert!(Price::new(TICK_SIZE).is_ok());
     }
 
     #[test]

--- a/crates/domain/src/types/price.rs
+++ b/crates/domain/src/types/price.rs
@@ -1,0 +1,129 @@
+//! Fixed-point price as a tick count.
+
+use std::fmt;
+
+use crate::consts::TICK_SIZE;
+
+/// Fixed-point price expressed as a raw tick count.
+///
+/// # Invariants
+/// - Inner value is strictly positive.
+/// - Inner value is a multiple of [`TICK_SIZE`].
+/// - The inner field is private; callers obtain a `Price` only through
+///   [`Price::new`] or [`TryFrom<i64>`], so the invariants hold by
+///   construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Price(i64);
+
+impl Price {
+    /// Smallest legal price (one tick).
+    pub const MIN: Self = Self(TICK_SIZE);
+
+    /// Largest representable price, rounded down to a `TICK_SIZE`
+    /// multiple. While `TICK_SIZE == 1` this equals `i64::MAX`; the
+    /// rounding stays in the source so a future PR that raises
+    /// `TICK_SIZE` does not silently produce an invalid `MAX`.
+    #[allow(clippy::modulo_one)]
+    pub const MAX: Self = Self(i64::MAX - (i64::MAX % TICK_SIZE));
+
+    /// Construct from a raw tick count.
+    ///
+    /// # Errors
+    /// Returns [`PriceError::NonPositive`] when `ticks <= 0`.
+    /// Returns [`PriceError::TickViolation`] when `ticks % TICK_SIZE != 0`.
+    // Clippy's `modulo_one` lint fires while `TICK_SIZE == 1` because the
+    // tick check is structurally a no-op. Kept deliberately so the wire-
+    // visible `RejectReason::TickViolation` path stays live the moment a
+    // future PR raises `TICK_SIZE`.
+    #[allow(clippy::modulo_one)]
+    #[inline]
+    pub const fn new(ticks: i64) -> Result<Self, PriceError> {
+        if ticks <= 0 {
+            return Err(PriceError::NonPositive);
+        }
+        if ticks % TICK_SIZE != 0 {
+            return Err(PriceError::TickViolation);
+        }
+        Ok(Self(ticks))
+    }
+
+    /// Raw tick count. Use only at the wire / serialization edge —
+    /// domain logic must operate on `Price` values, not on the
+    /// underlying integer.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_ticks(self) -> i64 {
+        self.0
+    }
+}
+
+impl TryFrom<i64> for Price {
+    type Error = PriceError;
+    #[inline]
+    fn try_from(v: i64) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for Price {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}t", self.0)
+    }
+}
+
+/// Validation error for [`Price::new`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PriceError {
+    /// `ticks <= 0`.
+    #[error("price must be strictly positive")]
+    NonPositive,
+    /// `ticks` is not a multiple of [`TICK_SIZE`].
+    #[error("price must be a multiple of TICK_SIZE")]
+    TickViolation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Price {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (1i64..=1_000_000)
+                .prop_map(|v| Price::new(v).expect("strategy yields valid Price"))
+                .boxed()
+        }
+    }
+
+    #[test]
+    fn test_price_new_zero_returns_non_positive() {
+        assert_eq!(Price::new(0), Err(PriceError::NonPositive));
+    }
+
+    #[test]
+    fn test_price_new_negative_returns_non_positive() {
+        assert_eq!(Price::new(-1), Err(PriceError::NonPositive));
+    }
+
+    #[test]
+    fn test_price_new_one_returns_ok() {
+        assert!(Price::new(1).is_ok());
+    }
+
+    #[test]
+    fn test_price_min_is_one_tick() {
+        assert_eq!(Price::MIN.as_ticks(), TICK_SIZE);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_price_roundtrip_ticks(p in any::<Price>()) {
+            let raw = p.as_ticks();
+            prop_assert_eq!(Price::new(raw).expect("roundtrip"), p);
+        }
+    }
+}

--- a/crates/domain/src/types/qty.rs
+++ b/crates/domain/src/types/qty.rs
@@ -1,0 +1,122 @@
+//! Order quantity as a lot count.
+
+use std::fmt;
+
+use crate::consts::LOT_SIZE;
+
+/// Order quantity expressed as a raw lot count.
+///
+/// # Invariants
+/// - Inner value is strictly positive.
+/// - Inner value is a multiple of [`LOT_SIZE`].
+/// - The inner field is private; callers obtain a `Qty` only through
+///   [`Qty::new`] or [`TryFrom<u64>`], so the invariants hold by
+///   construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Qty(u64);
+
+impl Qty {
+    /// Smallest legal quantity (one lot).
+    pub const MIN: Self = Self(LOT_SIZE);
+
+    /// Largest representable quantity, rounded down to a `LOT_SIZE`
+    /// multiple. While `LOT_SIZE == 1` this equals `u64::MAX`; the
+    /// rounding stays in the source so a future PR that raises
+    /// `LOT_SIZE` does not silently produce an invalid `MAX`.
+    #[allow(clippy::modulo_one)]
+    pub const MAX: Self = Self(u64::MAX - (u64::MAX % LOT_SIZE));
+
+    /// Construct from a raw lot count.
+    ///
+    /// # Errors
+    /// Returns [`QtyError::Zero`] when `lots == 0`.
+    /// Returns [`QtyError::LotViolation`] when `lots % LOT_SIZE != 0`.
+    // Clippy's `modulo_one` and `manual_is_multiple_of` lints fire while
+    // `LOT_SIZE == 1` because the lot check is structurally a no-op.
+    // Kept deliberately so the wire-visible `RejectReason::LotViolation`
+    // path stays live the moment a future PR raises `LOT_SIZE`.
+    #[allow(clippy::modulo_one, clippy::manual_is_multiple_of)]
+    #[inline]
+    pub const fn new(lots: u64) -> Result<Self, QtyError> {
+        if lots == 0 {
+            return Err(QtyError::Zero);
+        }
+        if lots % LOT_SIZE != 0 {
+            return Err(QtyError::LotViolation);
+        }
+        Ok(Self(lots))
+    }
+
+    /// Raw lot count. Use only at the wire / serialization edge.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_lots(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for Qty {
+    type Error = QtyError;
+    #[inline]
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for Qty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}q", self.0)
+    }
+}
+
+/// Validation error for [`Qty::new`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum QtyError {
+    /// `lots == 0`.
+    #[error("quantity must be strictly positive")]
+    Zero,
+    /// `lots` is not a multiple of [`LOT_SIZE`].
+    #[error("quantity must be a multiple of LOT_SIZE")]
+    LotViolation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Qty {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (1u64..=1_000_000)
+                .prop_map(|v| Qty::new(v).expect("strategy yields valid Qty"))
+                .boxed()
+        }
+    }
+
+    #[test]
+    fn test_qty_new_zero_returns_zero_error() {
+        assert_eq!(Qty::new(0), Err(QtyError::Zero));
+    }
+
+    #[test]
+    fn test_qty_new_one_returns_ok() {
+        assert!(Qty::new(1).is_ok());
+    }
+
+    #[test]
+    fn test_qty_min_is_one_lot() {
+        assert_eq!(Qty::MIN.as_lots(), LOT_SIZE);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_qty_roundtrip_lots(q in any::<Qty>()) {
+            let raw = q.as_lots();
+            prop_assert_eq!(Qty::new(raw).expect("roundtrip"), q);
+        }
+    }
+}

--- a/crates/domain/src/types/qty.rs
+++ b/crates/domain/src/types/qty.rs
@@ -91,8 +91,10 @@ mod tests {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
         fn arbitrary_with(_: ()) -> Self::Strategy {
+            // Generate as a multiple of LOT_SIZE so the strategy stays
+            // valid the moment a future PR raises LOT_SIZE above 1.
             (1u64..=1_000_000)
-                .prop_map(|v| Qty::new(v).expect("strategy yields valid Qty"))
+                .prop_map(|n| Qty::new(n * LOT_SIZE).expect("strategy yields valid Qty"))
                 .boxed()
         }
     }
@@ -103,8 +105,8 @@ mod tests {
     }
 
     #[test]
-    fn test_qty_new_one_returns_ok() {
-        assert!(Qty::new(1).is_ok());
+    fn test_qty_new_one_lot_returns_ok() {
+        assert!(Qty::new(LOT_SIZE).is_ok());
     }
 
     #[test]

--- a/crates/domain/src/types/recv_ts.rs
+++ b/crates/domain/src/types/recv_ts.rs
@@ -1,0 +1,74 @@
+//! Engine-stamped receive timestamp.
+
+use std::fmt;
+
+/// Receive timestamp in nanoseconds since the UNIX epoch.
+///
+/// # Invariants
+/// - Stamped by the gateway / engine via an injected `Clock` trait at
+///   the inbound decode boundary. The matching core never calls the
+///   wall clock directly — replay swaps in a deterministic stub.
+/// - This type does not call the wall clock — it carries a value the
+///   caller already has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct RecvTs(i64);
+
+impl RecvTs {
+    /// Zero-valued sentinel for "unset". Useful in tests and as a
+    /// neutral default in proptests; not a meaningful timestamp.
+    pub const ZERO: Self = Self(0);
+
+    /// Construct from a raw nanosecond count.
+    #[inline]
+    #[must_use]
+    pub const fn new(nanos: i64) -> Self {
+        Self(nanos)
+    }
+
+    /// Raw nanosecond count.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_nanos(self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for RecvTs {
+    #[inline]
+    fn from(v: i64) -> Self {
+        Self::new(v)
+    }
+}
+
+impl fmt::Display for RecvTs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "rts:{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for RecvTs {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            any::<i64>().prop_map(RecvTs::new).boxed()
+        }
+    }
+
+    #[test]
+    fn test_recv_ts_zero_is_zero() {
+        assert_eq!(RecvTs::ZERO.as_nanos(), 0);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_recv_ts_roundtrip(ts in any::<RecvTs>()) {
+            prop_assert_eq!(RecvTs::new(ts.as_nanos()), ts);
+        }
+    }
+}

--- a/crates/domain/src/types/reject_reason.rs
+++ b/crates/domain/src/types/reject_reason.rs
@@ -1,0 +1,156 @@
+//! Rejection reason codes.
+
+use std::fmt;
+
+/// Closed enumeration of rejection reasons emitted in execution
+/// reports. Wire-stable: numeric discriminants are part of the public
+/// contract and must not be reassigned.
+///
+/// New rejection reasons are added by appending — never by renumbering.
+/// `255 = Unknown` is reserved for forward-compatible decode of
+/// future schema versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum RejectReason {
+    /// Engine kill switch is engaged.
+    KillSwitched = 1,
+    /// Price field outside legal range (zero or negative).
+    InvalidPrice = 2,
+    /// Quantity field outside legal range (zero).
+    InvalidQty = 3,
+    /// Price not a multiple of `TICK_SIZE`.
+    TickViolation = 4,
+    /// Quantity not a multiple of `LOT_SIZE`.
+    LotViolation = 5,
+    /// Price differs from the reference by more than `PRICE_BAND_BPS`.
+    PriceBand = 6,
+    /// Account already at `MAX_OPEN_ORDERS_PER_ACCT`.
+    MaxOpenOrders = 7,
+    /// Adding this order would exceed `MAX_NOTIONAL_PER_ACCT`.
+    MaxNotional = 8,
+    /// Cancel / cancel-replace targeted an unknown `order_id`.
+    UnknownOrderId = 9,
+    /// New order's `order_id` already exists for this account.
+    DuplicateOrderId = 10,
+    /// Post-only order would cross on arrival.
+    PostOnlyWouldCross = 11,
+    /// Self-trade prevention triggered (cancel-both policy).
+    SelfTradePrevented = 12,
+    /// Market order arrived against an empty aggressive side.
+    MarketOrderInEmptyBook = 13,
+    /// Inbound message referenced an account not bound to this session.
+    UnknownAccount = 14,
+    /// Inbound payload failed wire-protocol validation.
+    MalformedMessage = 15,
+}
+
+impl RejectReason {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for RejectReason {
+    type Error = RejectReasonError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::KillSwitched),
+            2 => Ok(Self::InvalidPrice),
+            3 => Ok(Self::InvalidQty),
+            4 => Ok(Self::TickViolation),
+            5 => Ok(Self::LotViolation),
+            6 => Ok(Self::PriceBand),
+            7 => Ok(Self::MaxOpenOrders),
+            8 => Ok(Self::MaxNotional),
+            9 => Ok(Self::UnknownOrderId),
+            10 => Ok(Self::DuplicateOrderId),
+            11 => Ok(Self::PostOnlyWouldCross),
+            12 => Ok(Self::SelfTradePrevented),
+            13 => Ok(Self::MarketOrderInEmptyBook),
+            14 => Ok(Self::UnknownAccount),
+            15 => Ok(Self::MalformedMessage),
+            other => Err(RejectReasonError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for RejectReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Decode error for [`RejectReason::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RejectReasonError {
+    /// Wire payload contained a discriminant outside the assigned
+    /// range. Discriminant `255` is reserved for forward-compatible
+    /// decode of future schema versions.
+    #[error("unknown RejectReason discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for RejectReason {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![
+                Just(Self::KillSwitched),
+                Just(Self::InvalidPrice),
+                Just(Self::InvalidQty),
+                Just(Self::TickViolation),
+                Just(Self::LotViolation),
+                Just(Self::PriceBand),
+                Just(Self::MaxOpenOrders),
+                Just(Self::MaxNotional),
+                Just(Self::UnknownOrderId),
+                Just(Self::DuplicateOrderId),
+                Just(Self::PostOnlyWouldCross),
+                Just(Self::SelfTradePrevented),
+                Just(Self::MarketOrderInEmptyBook),
+                Just(Self::UnknownAccount),
+                Just(Self::MalformedMessage),
+            ]
+            .boxed()
+        }
+    }
+
+    #[test]
+    fn test_reject_reason_discriminants_are_stable() {
+        assert_eq!(RejectReason::KillSwitched.as_u8(), 1);
+        assert_eq!(RejectReason::MalformedMessage.as_u8(), 15);
+    }
+
+    #[test]
+    fn test_reject_reason_try_from_unknown_returns_err() {
+        assert_eq!(
+            RejectReason::try_from(0),
+            Err(RejectReasonError::Unknown(0))
+        );
+        assert_eq!(
+            RejectReason::try_from(16),
+            Err(RejectReasonError::Unknown(16))
+        );
+        assert_eq!(
+            RejectReason::try_from(255),
+            Err(RejectReasonError::Unknown(255))
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_reject_reason_u8_roundtrip(r in any::<RejectReason>()) {
+            prop_assert_eq!(RejectReason::try_from(r.as_u8()).expect("roundtrip"), r);
+        }
+    }
+}

--- a/crates/domain/src/types/reject_reason.rs
+++ b/crates/domain/src/types/reject_reason.rs
@@ -7,8 +7,10 @@ use std::fmt;
 /// contract and must not be reassigned.
 ///
 /// New rejection reasons are added by appending — never by renumbering.
-/// `255 = Unknown` is reserved for forward-compatible decode of
-/// future schema versions.
+/// Decode of any unassigned discriminant returns
+/// [`RejectReasonError::Unknown`]; discriminant `255` is reserved as a
+/// sentinel that must not be assigned without a coordinated schema-
+/// version bump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum RejectReason {

--- a/crates/domain/src/types/side.rs
+++ b/crates/domain/src/types/side.rs
@@ -1,0 +1,103 @@
+//! Order side.
+
+use std::fmt;
+
+/// Order side. Wire-stable: numeric discriminants are part of the
+/// public contract and must not be reassigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Side {
+    /// Buy side.
+    Bid = 1,
+    /// Sell side.
+    Ask = 2,
+}
+
+impl Side {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Opposite side. `Bid -> Ask`, `Ask -> Bid`.
+    #[inline]
+    #[must_use]
+    pub const fn opposite(self) -> Self {
+        match self {
+            Self::Bid => Self::Ask,
+            Self::Ask => Self::Bid,
+        }
+    }
+}
+
+impl TryFrom<u8> for Side {
+    type Error = SideError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::Bid),
+            2 => Ok(Self::Ask),
+            other => Err(SideError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for Side {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bid => f.write_str("Bid"),
+            Self::Ask => f.write_str("Ask"),
+        }
+    }
+}
+
+/// Decode error for [`Side::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SideError {
+    /// Wire payload contained a discriminant outside `{1, 2}`.
+    #[error("unknown Side discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Side {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![Just(Side::Bid), Just(Side::Ask)].boxed()
+        }
+    }
+
+    #[test]
+    fn test_side_as_u8_assigns_one_and_two() {
+        assert_eq!(Side::Bid.as_u8(), 1);
+        assert_eq!(Side::Ask.as_u8(), 2);
+    }
+
+    #[test]
+    fn test_side_opposite_swaps() {
+        assert_eq!(Side::Bid.opposite(), Side::Ask);
+        assert_eq!(Side::Ask.opposite(), Side::Bid);
+    }
+
+    #[test]
+    fn test_side_try_from_unknown_returns_err() {
+        assert_eq!(Side::try_from(0), Err(SideError::Unknown(0)));
+        assert_eq!(Side::try_from(3), Err(SideError::Unknown(3)));
+        assert_eq!(Side::try_from(255), Err(SideError::Unknown(255)));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_side_u8_roundtrip(s in any::<Side>()) {
+            prop_assert_eq!(Side::try_from(s.as_u8()).expect("roundtrip"), s);
+        }
+    }
+}

--- a/crates/domain/src/types/tif.rs
+++ b/crates/domain/src/types/tif.rs
@@ -1,0 +1,93 @@
+//! Time-in-force.
+
+use std::fmt;
+
+/// Time-in-force policy. Wire-stable: numeric discriminants are part
+/// of the public contract and must not be reassigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Tif {
+    /// Good-til-cancel — rests on the book until matched or cancelled.
+    Gtc = 1,
+    /// Immediate-or-cancel — fills as much as possible, cancels the
+    /// remainder. Never rests.
+    Ioc = 2,
+    /// Post-only — rejected on arrival if it would cross. Otherwise
+    /// behaves as `Gtc`.
+    PostOnly = 3,
+}
+
+impl Tif {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for Tif {
+    type Error = TifError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::Gtc),
+            2 => Ok(Self::Ioc),
+            3 => Ok(Self::PostOnly),
+            other => Err(TifError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for Tif {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Gtc => f.write_str("GTC"),
+            Self::Ioc => f.write_str("IOC"),
+            Self::PostOnly => f.write_str("POST_ONLY"),
+        }
+    }
+}
+
+/// Decode error for [`Tif::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TifError {
+    /// Wire payload contained a discriminant outside `{1, 2, 3}`.
+    #[error("unknown Tif discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Tif {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![Just(Tif::Gtc), Just(Tif::Ioc), Just(Tif::PostOnly)].boxed()
+        }
+    }
+
+    #[test]
+    fn test_tif_as_u8_assigns_one_two_three() {
+        assert_eq!(Tif::Gtc.as_u8(), 1);
+        assert_eq!(Tif::Ioc.as_u8(), 2);
+        assert_eq!(Tif::PostOnly.as_u8(), 3);
+    }
+
+    #[test]
+    fn test_tif_try_from_unknown_returns_err() {
+        assert_eq!(Tif::try_from(0), Err(TifError::Unknown(0)));
+        assert_eq!(Tif::try_from(4), Err(TifError::Unknown(4)));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_tif_u8_roundtrip(t in any::<Tif>()) {
+            prop_assert_eq!(Tif::try_from(t.as_u8()).expect("roundtrip"), t);
+        }
+    }
+}

--- a/crates/domain/src/types/trade_id.rs
+++ b/crates/domain/src/types/trade_id.rs
@@ -93,7 +93,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn proptest_trade_id_strictly_monotonic(seed in 0u64..u64::MAX - 1) {
+        fn proptest_trade_id_strictly_monotonic(seed in 0u64..=u64::MAX - 1) {
             let t0 = TradeId::new(seed);
             let t1 = t0.next().expect("no overflow");
             prop_assert!(t1 > t0);

--- a/crates/domain/src/types/trade_id.rs
+++ b/crates/domain/src/types/trade_id.rs
@@ -1,0 +1,103 @@
+//! Engine-internal trade identifier.
+
+use std::fmt;
+
+/// Engine-internal monotonic trade identifier.
+///
+/// # Invariants
+/// - Inner value increments by exactly one per emitted trade via
+///   [`TradeId::next`].
+/// - Construction via [`TradeId::INITIAL`] is the engine's normal
+///   start-of-day path; [`TradeId::new`] is provided so the replay
+///   harness can seed from a recorded value.
+/// - Arithmetic is checked — overflow returns [`TradeIdError::Overflow`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct TradeId(u64);
+
+impl TradeId {
+    /// Initial value. The engine starts every run from here.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct from a raw `u64`. Used by the replay harness.
+    #[inline]
+    #[must_use]
+    pub const fn new(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Advance to the next trade id.
+    ///
+    /// # Errors
+    /// Returns [`TradeIdError::Overflow`] when the counter would exceed
+    /// [`u64::MAX`].
+    #[inline]
+    pub const fn next(self) -> Result<Self, TradeIdError> {
+        match self.0.checked_add(1) {
+            Some(v) => Ok(Self(v)),
+            None => Err(TradeIdError::Overflow),
+        }
+    }
+
+    /// Raw counter value. Use only at the wire / serialization edge.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for TradeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "trd:{}", self.0)
+    }
+}
+
+/// Error type for [`TradeId::next`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TradeIdError {
+    /// Counter would exceed [`u64::MAX`].
+    #[error("trade_id overflow")]
+    Overflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for TradeId {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            (0u64..=u64::MAX).prop_map(TradeId::new).boxed()
+        }
+    }
+
+    #[test]
+    fn test_trade_id_initial_is_zero() {
+        assert_eq!(TradeId::INITIAL.as_raw(), 0);
+    }
+
+    #[test]
+    fn test_trade_id_next_increments_by_one() {
+        let s = TradeId::new(99).next().expect("no overflow");
+        assert_eq!(s.as_raw(), 100);
+    }
+
+    #[test]
+    fn test_trade_id_next_overflow_returns_err() {
+        assert_eq!(TradeId::new(u64::MAX).next(), Err(TradeIdError::Overflow));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_trade_id_strictly_monotonic(seed in 0u64..u64::MAX - 1) {
+            let t0 = TradeId::new(seed);
+            let t1 = t0.next().expect("no overflow");
+            prop_assert!(t1 > t0);
+            prop_assert_eq!(t1.as_raw(), seed + 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Foundation crate. Lift every domain primitive into its own type so
illegal states cannot compile and integer mix-ups across crate
boundaries are impossible. Every other crate builds on this.

## Changes

- 8 newtypes (\`Price\`, \`Qty\`, \`OrderId\`, \`AccountId\`,
  \`EngineSeq\`, \`TradeId\`, \`ClientTs\`, \`RecvTs\`) — each
  \`#[repr(transparent)]\`, private inner, validated \`const fn new\`,
  raw \`as_*\` accessor, \`Display\`, and a \`proptest::Arbitrary\`
  impl under \`#[cfg(test)]\`.
- 5 wire-stable enums (\`Side\`, \`OrderType\`, \`Tif\`,
  \`RejectReason\`, \`CancelReason\`) — \`#[repr(u8)]\` with explicit
  numeric discriminants, \`TryFrom<u8>\`, per-enum \`thiserror\` decode
  error.
- \`consts.rs\` with \`TICK_SIZE\`, \`LOT_SIZE\`, \`PRICE_BAND_BPS\`,
  \`MAX_OPEN_ORDERS_PER_ACCT\`, \`MAX_NOTIONAL_PER_ACCT\`, \`SYMBOL\`.
- \`DomainError\` aggregator over every per-type error via \`#[from]\`.
- \`crates/domain/Cargo.toml\` adds \`thiserror\` (already in workspace
  deps; no new third-party crate introduced).

## Technical decisions

**\`EngineSeq\` / \`TradeId\` API.** Both expose
\`pub const INITIAL: Self\`, infallible \`new(v)\` for replay seeding,
and a checked \`next() -> Result<Self, OverflowError>\`. CLAUDE.md
forbids \`saturating_*\` / \`wrapping_*\` on protocol counters; this is
the correct shape.

**\`OrderId\` / \`AccountId\`.** Validated \`> 0\` rather than wrapping
\`NonZeroU64\` / \`NonZeroU32\`, because \`NonZero*\` interferes with
the \`#[repr(transparent)] + Display + Arbitrary\` pattern the skill
prescribes for every newtype.

**Wire-stable enum discriminants.** Explicit \`= N\` on every variant.
\`RejectReason\` reserves \`255 = Unknown\` for forward-compatible
decode of future schema versions. New variants are added by appending,
never by renumbering.

**\`MAX_NOTIONAL_PER_ACCT\` is \`u128\`.** A market order's worst-case
far-touch fill price would overflow \`u64\` under heavy size; the risk
check (#11) bounds notional with this constant, and the \`u128\` head-
room keeps the check honest.

**Modulo-on-one tick / lot guards.** \`if ticks % TICK_SIZE != 0\` and
\`if lots % LOT_SIZE != 0\` are dead branches while both constants are
\`1\`, which trips clippy's \`modulo_one\` lint. The lint is locally
allowed with a rationale comment — the wire-visible
\`RejectReason::TickViolation\` and \`LotViolation\` paths must stay
live the moment a future PR raises either constant; removing the check
now would silently strip that defense.

## Public API impact

New public surface re-exported from \`domain::\`:

\`\`\`rust
pub use {AccountId, AccountIdError, CancelReason, CancelReasonError,
         ClientTs, EngineSeq, EngineSeqError, OrderId, OrderIdError,
         OrderType, OrderTypeError, Price, PriceError, Qty, QtyError,
         RecvTs, RejectReason, RejectReasonError, Side, SideError,
         Tif, TifError, TradeId, TradeIdError};
pub use error::DomainError;
pub mod consts;
\`\`\`

\`#![warn(missing_docs)]\` on \`crates/domain/src/lib.rs\` — every
\`pub\` item carries a \`///\` doc with a \`# Invariants\` section
where applicable.

## Determinism / hot-path

N/A. \`crates/domain\` is not on the matching hot path and contains no
wall-clock reads, randomness, or hash-based iteration. No
\`determinism-auditor\` or \`hotpath-reviewer\` invocation needed.

## Testing

- 43 tests via \`cargo nextest run -p domain\` — all green.
- One \`Arbitrary\` impl per type. Per-type unit tests cover happy path
  + every documented error case. Per-type proptest covers the
  \`encode -> decode\` (or \`new -> as_raw -> new\`) roundtrip.
- \`proptest_engine_seq_strictly_monotonic\` and
  \`proptest_trade_id_strictly_monotonic\` lock the monotonic
  invariant for the counters.

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo nextest run\` clean (43 passed; 0 failed)
- [x] \`cargo build --release\` clean

## Checklist

- [x] No \`f32\` / \`f64\` anywhere in \`crates/domain/\`
- [x] No magic numbers — every literal traces to \`consts.rs\`
- [x] Every newtype \`#[repr(transparent)]\`, private inner, validated constructor
- [x] \`Copy\` on every newtype (hot-path pass-by-value)
- [x] Every \`pub\` type has \`///\` docs; types with invariants have \`# Invariants\`
- [x] \`thiserror\` enums per type — no bare \`anyhow\`, no \`Result<T, String>\`
- [x] No \`.unwrap()\` / \`.expect()\` / unchecked indexing in production code
- [x] Module boundaries respected — \`crates/domain\` depends on nothing
- [x] Every \`unsafe\` block carries a \`// SAFETY:\` comment — N/A, no \`unsafe\` introduced
- [x] No new dependencies added beyond \`thiserror\` (already in workspace allowances)

Closes #3