### PR TITLE
Inbound wire codec — bespoke binary protocol (#4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde_json        = "1"
 hdrhistogram      = "7.5"
 criterion         = { version = "0.8", default-features = false, features = ["html_reports"] }
 proptest          = "1.11"
+zerocopy          = { version = "0.8", features = ["derive"] }
 
 [profile.release]
 opt-level     = 3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# hft-clob-core
+
+Single-symbol central-limit-order-book (CLOB) matching engine in Rust.
+
+> Status: in active development. The README is grown one section per
+> implementation issue; sections marked **stub** will be expanded as
+> their owning issue lands. Full architecture / how-to-run /
+> microstructure write-up arrive with milestone **M8 Docs + Ship**
+> (issues #18 / #19 / #20).
+
+## Wire protocol *(stub — expanded in #5)*
+
+The on-wire format is bespoke, fixed-size, and little-endian. Every
+message is length-prefixed:
+
+```
+| len: u32 LE | kind: u8 | payload: [u8; len - 1] |
+```
+
+`len` counts bytes from `kind` through the end of the payload, so the
+total frame size is `4 + len`.
+
+Per-message field offsets and widths live in
+[`docs/protocol.md`](docs/protocol.md) — single source of truth for
+encoders, decoders, and roundtrip tests.
+
+### Inbound message kinds
+
+| Kind | Hex   | Name              | Payload size | Purpose                             |
+|------|-------|-------------------|--------------|-------------------------------------|
+| 1    | 0x01  | `NewOrder`        | 40 bytes     | Limit or market order entry         |
+| 2    | 0x02  | `CancelOrder`     | 24 bytes     | Cancel a resting order              |
+| 3    | 0x03  | `CancelReplace`   | 40 bytes     | Modify a resting order              |
+| 4    | 0x04  | `MassCancel`      | 16 bytes     | Cancel all resting orders for an account |
+| 5    | 0x05  | `KillSwitchSet`   | 24 bytes     | Admin halt / resume                 |
+| 6    | 0x06  | `SnapshotRequest` | 16 bytes     | Operator dump of book + engine state |
+
+Outbound message kinds (101+) land in #5.
+
+### Decode invariants
+
+- Frame length must match the declared `len`; truncation returns
+  `WireError::Truncated`.
+- `kind` must be assigned; otherwise `WireError::UnknownKind(byte)`.
+- Every reserved padding byte must be zero; otherwise
+  `WireError::NonZeroPad(offset)`.
+- Each integer field is converted to its `domain::` newtype
+  (`Price`, `Qty`, `OrderId`, `AccountId`, …) at the boundary; failures
+  surface as `WireError::Domain(_)`.
+
+`WIRE_VERSION = 1`. Bumped on any layout change to inbound or outbound
+message bodies.

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -11,9 +11,8 @@ repository.workspace = true
 
 [dependencies]
 domain = { workspace = true }
-ironsbe-core = { workspace = true }
-ironsbe-derive = { workspace = true }
-bytes.workspace = true
+thiserror.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/wire/src/error.rs
+++ b/crates/wire/src/error.rs
@@ -28,6 +28,24 @@ pub enum WireError {
         /// Observed payload size in bytes.
         got: usize,
     },
+    /// A wire-only payload enum (e.g. `KillSwitchState`) carried a
+    /// discriminant outside its assigned range. Distinct from
+    /// [`WireError::UnknownKind`], which targets the frame header's
+    /// message-kind byte.
+    #[error("invalid `{field}` discriminant: {value}")]
+    InvalidEnumValue {
+        /// Name of the wire field that failed to decode.
+        field: &'static str,
+        /// Observed discriminant byte.
+        value: u8,
+    },
+    /// `Frame::write` was called with a payload whose framed size
+    /// (`1 + payload.len()`) exceeds [`u32::MAX`]. Inbound payloads in
+    /// this crate are fixed-size and far below that ceiling, but the
+    /// encoder rejects rather than silently truncating the length
+    /// prefix.
+    #[error("framed payload size exceeds u32::MAX: {0} bytes")]
+    PayloadTooLarge(usize),
     /// A field failed `domain` validation (e.g. zero `OrderId`,
     /// non-positive `Price`, unknown `Side` discriminant).
     #[error(transparent)]

--- a/crates/wire/src/error.rs
+++ b/crates/wire/src/error.rs
@@ -1,0 +1,42 @@
+//! Wire-protocol error type.
+
+use thiserror::Error;
+
+use domain::DomainError;
+
+/// Aggregated decode / framing error for the wire crate.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WireError {
+    /// Buffer was shorter than the declared frame length, or shorter
+    /// than the fixed-size payload of the indicated message kind.
+    #[error("frame buffer truncated")]
+    Truncated,
+    /// Header contained a kind discriminant outside the assigned range.
+    #[error("unknown message kind: {0:#04x}")]
+    UnknownKind(u8),
+    /// A reserved padding byte was non-zero, indicating a malformed or
+    /// version-mismatched payload.
+    #[error("non-zero padding byte at offset {0}")]
+    NonZeroPad(usize),
+    /// Payload size did not match the fixed-size layout of the indicated
+    /// message kind.
+    #[error("payload size mismatch: expected {expected}, got {got}")]
+    PayloadSize {
+        /// Expected fixed payload size in bytes.
+        expected: usize,
+        /// Observed payload size in bytes.
+        got: usize,
+    },
+    /// A field failed `domain` validation (e.g. zero `OrderId`,
+    /// non-positive `Price`, unknown `Side` discriminant).
+    #[error(transparent)]
+    Domain(#[from] DomainError),
+}
+
+/// Lift any per-type domain validation error into a [`WireError`] via
+/// [`DomainError`]. Avoids spelling out two `.into()` hops per call site.
+#[inline]
+pub(crate) fn to_wire<E: Into<DomainError>>(e: E) -> WireError {
+    WireError::Domain(e.into())
+}

--- a/crates/wire/src/framing.rs
+++ b/crates/wire/src/framing.rs
@@ -72,15 +72,50 @@ pub struct Frame<'a> {
     pub payload: &'a [u8],
 }
 
+/// Outcome of [`Frame::parse_or_skip`]. Lets callers advance past a
+/// frame whose `kind` byte they do not recognise without losing
+/// stream synchronization.
+#[derive(Debug, Clone, Copy)]
+pub enum ParseOutcome<'a> {
+    /// Header carried a known [`MessageKind`]. Consume `total` bytes
+    /// and act on `frame`.
+    Frame(Frame<'a>),
+    /// Header carried an unrecognised kind byte. Consume `total` bytes
+    /// and continue; the caller's transport is now resynced.
+    UnknownKind(u8),
+}
+
 impl<'a> Frame<'a> {
-    /// Parse one frame from the start of `buf`. Returns the frame and
-    /// the number of bytes consumed (`4 + len`).
+    /// Parse one frame from the start of `buf`, strictly. Returns the
+    /// frame and the number of bytes consumed (`4 + len`).
     ///
     /// # Errors
     /// - [`WireError::Truncated`] if `buf` is shorter than the declared frame.
     /// - [`WireError::UnknownKind`] if the `kind` byte is not assigned.
+    ///
+    /// Use [`Frame::parse_or_skip`] when the caller wants to resync
+    /// past unknown kinds rather than abort the stream.
     #[inline]
     pub fn parse(buf: &'a [u8]) -> Result<(Self, usize), WireError> {
+        match Self::parse_or_skip(buf)? {
+            (ParseOutcome::Frame(frame), total) => Ok((frame, total)),
+            (ParseOutcome::UnknownKind(byte), _) => Err(WireError::UnknownKind(byte)),
+        }
+    }
+
+    /// Parse one frame, treating an unknown `kind` byte as a recoverable
+    /// outcome rather than an error. Returns the parsed envelope and the
+    /// number of bytes consumed (`4 + len`).
+    ///
+    /// This is the canonical resync entry point: a caller advancing
+    /// `total` bytes after every call always lands at the next frame
+    /// boundary, regardless of whether the kind was recognised.
+    ///
+    /// # Errors
+    /// [`WireError::Truncated`] if `buf` is shorter than the declared
+    /// frame. Truncation is unrecoverable here because the length prefix
+    /// cannot be trusted.
+    pub fn parse_or_skip(buf: &'a [u8]) -> Result<(ParseOutcome<'a>, usize), WireError> {
         let len_arr: [u8; FRAME_LEN_BYTES] = buf
             .get(..FRAME_LEN_BYTES)
             .ok_or(WireError::Truncated)?
@@ -95,19 +130,34 @@ impl<'a> Frame<'a> {
         let kind_byte = *frame_bytes
             .get(FRAME_LEN_BYTES)
             .ok_or(WireError::Truncated)?;
-        let kind = MessageKind::try_from(kind_byte)?;
-        let payload = frame_bytes
-            .get(FRAME_HEADER_BYTES..)
-            .ok_or(WireError::Truncated)?;
-        Ok((Frame { kind, payload }, total))
+        let outcome = match MessageKind::try_from(kind_byte) {
+            Ok(kind) => {
+                let payload = frame_bytes
+                    .get(FRAME_HEADER_BYTES..)
+                    .ok_or(WireError::Truncated)?;
+                ParseOutcome::Frame(Frame { kind, payload })
+            }
+            Err(_) => ParseOutcome::UnknownKind(kind_byte),
+        };
+        Ok((outcome, total))
     }
 
     /// Append a framed message to `out`. Layout matches [`Frame::parse`].
-    pub fn write(kind: MessageKind, payload: &[u8], out: &mut Vec<u8>) {
-        let len = (FRAME_KIND_BYTES + payload.len()) as u32;
+    ///
+    /// # Errors
+    /// [`WireError::PayloadTooLarge`] if `1 + payload.len()` exceeds
+    /// [`u32::MAX`]. Inbound payloads in this crate are fixed-size and
+    /// far below that ceiling, but the encoder refuses to silently
+    /// truncate the length prefix.
+    pub fn write(kind: MessageKind, payload: &[u8], out: &mut Vec<u8>) -> Result<(), WireError> {
+        let framed = FRAME_KIND_BYTES
+            .checked_add(payload.len())
+            .ok_or(WireError::PayloadTooLarge(payload.len()))?;
+        let len = u32::try_from(framed).map_err(|_| WireError::PayloadTooLarge(framed))?;
         out.extend_from_slice(&len.to_le_bytes());
         out.push(kind.as_u8());
         out.extend_from_slice(payload);
+        Ok(())
     }
 }
 
@@ -119,7 +169,7 @@ mod tests {
     fn test_frame_write_then_parse_roundtrip() {
         let payload = [1u8, 2, 3, 4, 5];
         let mut buf = Vec::new();
-        Frame::write(MessageKind::NewOrder, &payload, &mut buf);
+        Frame::write(MessageKind::NewOrder, &payload, &mut buf).expect("fits");
         let (frame, consumed) = Frame::parse(&buf).expect("parse");
         assert_eq!(frame.kind, MessageKind::NewOrder);
         assert_eq!(frame.payload, &payload);
@@ -149,6 +199,39 @@ mod tests {
             Frame::parse(&buf),
             Err(WireError::UnknownKind(0xFF))
         ));
+    }
+
+    #[test]
+    fn test_frame_parse_or_skip_unknown_kind_returns_outcome() {
+        // Unknown kind 0xAB followed by 2 trailing payload bytes —
+        // declared len = 3 (kind + 2). parse_or_skip must report the
+        // kind byte and the full consumed size so the caller can
+        // resync.
+        let mut buf = vec![3u8, 0, 0, 0]; // len = 3
+        buf.push(0xAB);
+        buf.extend_from_slice(&[0u8; 2]);
+        let (outcome, consumed) = Frame::parse_or_skip(&buf).expect("framing valid");
+        assert_eq!(consumed, buf.len());
+        match outcome {
+            ParseOutcome::UnknownKind(byte) => assert_eq!(byte, 0xAB),
+            ParseOutcome::Frame(_) => panic!("expected UnknownKind"),
+        }
+    }
+
+    #[test]
+    fn test_frame_parse_or_skip_known_kind_returns_frame() {
+        let payload = [9u8, 8, 7];
+        let mut buf = Vec::new();
+        Frame::write(MessageKind::CancelOrder, &payload, &mut buf).expect("fits");
+        let (outcome, consumed) = Frame::parse_or_skip(&buf).expect("framing valid");
+        assert_eq!(consumed, buf.len());
+        match outcome {
+            ParseOutcome::Frame(frame) => {
+                assert_eq!(frame.kind, MessageKind::CancelOrder);
+                assert_eq!(frame.payload, &payload);
+            }
+            ParseOutcome::UnknownKind(_) => panic!("expected Frame"),
+        }
     }
 
     #[test]

--- a/crates/wire/src/framing.rs
+++ b/crates/wire/src/framing.rs
@@ -1,0 +1,162 @@
+//! Length-prefixed framing.
+//!
+//! Layout: `[len: u32 LE][kind: u8][payload: u8; len - 1]`.
+//! `len` counts bytes from the `kind` byte through the end of the
+//! payload, so total frame size = `4 + len`. Decoders that encounter an
+//! unknown `kind` advance `len` bytes and continue.
+//!
+//! See `docs/protocol.md` for the per-message layouts.
+
+use crate::WireError;
+
+/// Number of bytes used to encode the frame length prefix.
+pub const FRAME_LEN_BYTES: usize = 4;
+/// Number of bytes used to encode the message-kind discriminant.
+pub const FRAME_KIND_BYTES: usize = 1;
+/// Total header size in bytes: `len` prefix + `kind` byte.
+pub const FRAME_HEADER_BYTES: usize = FRAME_LEN_BYTES + FRAME_KIND_BYTES;
+
+/// Inbound message kind. Numeric discriminants are wire-stable and must
+/// match the table in `docs/protocol.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum MessageKind {
+    /// `NewOrder` — limit or market order entry.
+    NewOrder = 0x01,
+    /// `CancelOrder` — explicit cancel of a resting order.
+    CancelOrder = 0x02,
+    /// `CancelReplace` — modify a resting order in place.
+    CancelReplace = 0x03,
+    /// `MassCancel` — cancel every resting order on an account.
+    MassCancel = 0x04,
+    /// `KillSwitchSet` — admin halt / resume of the engine.
+    KillSwitchSet = 0x05,
+    /// `SnapshotRequest` — operator dump of book + engine state.
+    SnapshotRequest = 0x06,
+}
+
+impl MessageKind {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for MessageKind {
+    type Error = WireError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, WireError> {
+        match v {
+            0x01 => Ok(Self::NewOrder),
+            0x02 => Ok(Self::CancelOrder),
+            0x03 => Ok(Self::CancelReplace),
+            0x04 => Ok(Self::MassCancel),
+            0x05 => Ok(Self::KillSwitchSet),
+            0x06 => Ok(Self::SnapshotRequest),
+            other => Err(WireError::UnknownKind(other)),
+        }
+    }
+}
+
+/// One parsed frame: a message kind plus a borrowed payload slice.
+///
+/// `Frame` does NOT own the buffer; callers feed `&[u8]` from the
+/// inbound socket. Lifetimes follow the input.
+#[derive(Debug, Clone, Copy)]
+pub struct Frame<'a> {
+    /// Discriminant from the frame header.
+    pub kind: MessageKind,
+    /// Raw payload bytes (everything after the `kind` byte).
+    pub payload: &'a [u8],
+}
+
+impl<'a> Frame<'a> {
+    /// Parse one frame from the start of `buf`. Returns the frame and
+    /// the number of bytes consumed (`4 + len`).
+    ///
+    /// # Errors
+    /// - [`WireError::Truncated`] if `buf` is shorter than the declared frame.
+    /// - [`WireError::UnknownKind`] if the `kind` byte is not assigned.
+    #[inline]
+    pub fn parse(buf: &'a [u8]) -> Result<(Self, usize), WireError> {
+        let len_arr: [u8; FRAME_LEN_BYTES] = buf
+            .get(..FRAME_LEN_BYTES)
+            .ok_or(WireError::Truncated)?
+            .try_into()
+            .map_err(|_| WireError::Truncated)?;
+        let len = u32::from_le_bytes(len_arr) as usize;
+        if len < FRAME_KIND_BYTES {
+            return Err(WireError::Truncated);
+        }
+        let total = FRAME_LEN_BYTES + len;
+        let frame_bytes = buf.get(..total).ok_or(WireError::Truncated)?;
+        let kind_byte = *frame_bytes
+            .get(FRAME_LEN_BYTES)
+            .ok_or(WireError::Truncated)?;
+        let kind = MessageKind::try_from(kind_byte)?;
+        let payload = frame_bytes
+            .get(FRAME_HEADER_BYTES..)
+            .ok_or(WireError::Truncated)?;
+        Ok((Frame { kind, payload }, total))
+    }
+
+    /// Append a framed message to `out`. Layout matches [`Frame::parse`].
+    pub fn write(kind: MessageKind, payload: &[u8], out: &mut Vec<u8>) {
+        let len = (FRAME_KIND_BYTES + payload.len()) as u32;
+        out.extend_from_slice(&len.to_le_bytes());
+        out.push(kind.as_u8());
+        out.extend_from_slice(payload);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_write_then_parse_roundtrip() {
+        let payload = [1u8, 2, 3, 4, 5];
+        let mut buf = Vec::new();
+        Frame::write(MessageKind::NewOrder, &payload, &mut buf);
+        let (frame, consumed) = Frame::parse(&buf).expect("parse");
+        assert_eq!(frame.kind, MessageKind::NewOrder);
+        assert_eq!(frame.payload, &payload);
+        assert_eq!(consumed, buf.len());
+    }
+
+    #[test]
+    fn test_frame_parse_truncated_len_returns_err() {
+        let buf = [0x01u8, 0x00, 0x00]; // only 3 bytes — needs 4 for len
+        assert!(matches!(Frame::parse(&buf), Err(WireError::Truncated)));
+    }
+
+    #[test]
+    fn test_frame_parse_truncated_payload_returns_err() {
+        // declares len = 10 but provides only kind + 2 payload bytes
+        let mut buf = vec![10u8, 0, 0, 0]; // len = 10
+        buf.push(0x01); // kind
+        buf.extend_from_slice(&[0u8; 2]);
+        assert!(matches!(Frame::parse(&buf), Err(WireError::Truncated)));
+    }
+
+    #[test]
+    fn test_frame_parse_unknown_kind_returns_err() {
+        let mut buf = vec![1u8, 0, 0, 0]; // len = 1 (kind only)
+        buf.push(0xFF);
+        assert!(matches!(
+            Frame::parse(&buf),
+            Err(WireError::UnknownKind(0xFF))
+        ));
+    }
+
+    #[test]
+    fn test_message_kind_try_from_unknown_returns_err() {
+        assert_eq!(MessageKind::try_from(0), Err(WireError::UnknownKind(0)));
+        assert_eq!(
+            MessageKind::try_from(0x7F),
+            Err(WireError::UnknownKind(0x7F))
+        );
+    }
+}

--- a/crates/wire/src/inbound/cancel_order.rs
+++ b/crates/wire/src/inbound/cancel_order.rs
@@ -1,0 +1,108 @@
+//! `CancelOrder` (kind = 0x02).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{AccountId, ClientTs, OrderId};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 24 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct CancelOrderWire {
+    /// Client-stamped timestamp.
+    pub client_ts: u64,
+    /// Order to cancel.
+    pub order_id: u64,
+    /// Account binding.
+    pub account_id: u32,
+    /// Reserved padding; decoder rejects non-zero.
+    pub _pad0: u32,
+}
+
+const _: () = assert!(core::mem::size_of::<CancelOrderWire>() == 24);
+
+const SIZE: usize = core::mem::size_of::<CancelOrderWire>();
+const PAD0_OFFSET: usize = 20;
+
+/// Domain-typed `CancelOrder`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CancelOrder {
+    /// Client-stamped timestamp.
+    pub client_ts: ClientTs,
+    /// Order to cancel.
+    pub order_id: OrderId,
+    /// Account binding.
+    pub account_id: AccountId,
+}
+
+/// Decode `CancelOrder` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<CancelOrder, WireError> {
+    let w = CancelOrderWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    if pad != 0 {
+        return Err(WireError::NonZeroPad(PAD0_OFFSET));
+    }
+    Ok(CancelOrder {
+        client_ts: ClientTs::new({ w.client_ts } as i64),
+        order_id: OrderId::new(w.order_id).map_err(to_wire)?,
+        account_id: AccountId::new(w.account_id).map_err(to_wire)?,
+    })
+}
+
+/// Encode `CancelOrder` into a payload buffer.
+pub fn encode(msg: &CancelOrder, out: &mut Vec<u8>) {
+    let w = CancelOrderWire {
+        client_ts: msg.client_ts.as_nanos() as u64,
+        order_id: msg.order_id.as_raw(),
+        account_id: msg.account_id.as_raw(),
+        _pad0: 0,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> CancelOrder {
+        CancelOrder {
+            client_ts: ClientTs::new(100),
+            order_id: OrderId::new(42).expect("ok"),
+            account_id: AccountId::new(7).expect("ok"),
+        }
+    }
+
+    #[test]
+    fn test_cancel_order_wire_size_is_24() {
+        assert_eq!(SIZE, 24);
+    }
+
+    #[test]
+    fn test_cancel_order_roundtrip() {
+        let msg = sample();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_cancel_order_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_cancel_order_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(), &mut buf);
+        buf[PAD0_OFFSET] = 0xAB;
+        assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+}

--- a/crates/wire/src/inbound/cancel_replace.rs
+++ b/crates/wire/src/inbound/cancel_replace.rs
@@ -1,0 +1,122 @@
+//! `CancelReplace` (kind = 0x03).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{AccountId, ClientTs, OrderId, Price, Qty};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 40 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct CancelReplaceWire {
+    /// Client-stamped timestamp.
+    pub client_ts: u64,
+    /// Resting order to be replaced.
+    pub order_id: u64,
+    /// Account that owns `order_id`.
+    pub account_id: u32,
+    /// Reserved padding; decoder rejects non-zero.
+    pub _pad0: u32,
+    /// New limit price in ticks.
+    pub new_price: i64,
+    /// New quantity in lots; `> 0`.
+    pub new_qty: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<CancelReplaceWire>() == 40);
+
+const SIZE: usize = core::mem::size_of::<CancelReplaceWire>();
+const PAD0_OFFSET: usize = 20;
+
+/// Domain-typed `CancelReplace`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CancelReplace {
+    /// Client-stamped timestamp.
+    pub client_ts: ClientTs,
+    /// Resting order to replace.
+    pub order_id: OrderId,
+    /// Account binding.
+    pub account_id: AccountId,
+    /// New price.
+    pub new_price: Price,
+    /// New quantity.
+    pub new_qty: Qty,
+}
+
+/// Decode `CancelReplace` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<CancelReplace, WireError> {
+    let w = CancelReplaceWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    if pad != 0 {
+        return Err(WireError::NonZeroPad(PAD0_OFFSET));
+    }
+    Ok(CancelReplace {
+        client_ts: ClientTs::new({ w.client_ts } as i64),
+        order_id: OrderId::new(w.order_id).map_err(to_wire)?,
+        account_id: AccountId::new(w.account_id).map_err(to_wire)?,
+        new_price: Price::new(w.new_price).map_err(to_wire)?,
+        new_qty: Qty::new(w.new_qty).map_err(to_wire)?,
+    })
+}
+
+/// Encode `CancelReplace` into a payload buffer.
+pub fn encode(msg: &CancelReplace, out: &mut Vec<u8>) {
+    let w = CancelReplaceWire {
+        client_ts: msg.client_ts.as_nanos() as u64,
+        order_id: msg.order_id.as_raw(),
+        account_id: msg.account_id.as_raw(),
+        _pad0: 0,
+        new_price: msg.new_price.as_ticks(),
+        new_qty: msg.new_qty.as_lots(),
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> CancelReplace {
+        CancelReplace {
+            client_ts: ClientTs::new(100),
+            order_id: OrderId::new(42).expect("ok"),
+            account_id: AccountId::new(7).expect("ok"),
+            new_price: Price::new(200).expect("ok"),
+            new_qty: Qty::new(11).expect("ok"),
+        }
+    }
+
+    #[test]
+    fn test_cancel_replace_wire_size_is_40() {
+        assert_eq!(SIZE, 40);
+    }
+
+    #[test]
+    fn test_cancel_replace_roundtrip() {
+        let msg = sample();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_cancel_replace_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_cancel_replace_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(), &mut buf);
+        buf[PAD0_OFFSET] = 0x01;
+        assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+}

--- a/crates/wire/src/inbound/kill_switch.rs
+++ b/crates/wire/src/inbound/kill_switch.rs
@@ -1,0 +1,168 @@
+//! `KillSwitchSet` (kind = 0x05).
+
+use std::fmt;
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::ClientTs;
+
+use crate::WireError;
+
+/// Wire layout — `#[repr(C, packed)]`, 24 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct KillSwitchSetWire {
+    /// Client-stamped timestamp.
+    pub client_ts: u64,
+    /// Shared-secret token; the engine compares against its admin token.
+    pub admin_token: u64,
+    /// `0` = resume, `1` = halt. Other values are decoded as
+    /// [`WireError::Domain`] downstream.
+    pub state: u8,
+    /// Reserved padding; every byte must be zero.
+    pub _pad0: [u8; 7],
+}
+
+const _: () = assert!(core::mem::size_of::<KillSwitchSetWire>() == 24);
+
+const SIZE: usize = core::mem::size_of::<KillSwitchSetWire>();
+const PAD0_OFFSET_BASE: usize = 17;
+
+/// Halt / resume command. Wire-stable: numeric discriminants are part
+/// of the public contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum KillSwitchState {
+    /// Lift the kill switch.
+    Resume = 0,
+    /// Engage the kill switch.
+    Halt = 1,
+}
+
+impl KillSwitchState {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for KillSwitchState {
+    type Error = WireError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, WireError> {
+        match v {
+            0 => Ok(Self::Resume),
+            1 => Ok(Self::Halt),
+            other => Err(WireError::UnknownKind(other)),
+        }
+    }
+}
+
+impl fmt::Display for KillSwitchState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Resume => f.write_str("Resume"),
+            Self::Halt => f.write_str("Halt"),
+        }
+    }
+}
+
+/// Domain-typed `KillSwitchSet`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KillSwitchSet {
+    /// Client-stamped timestamp.
+    pub client_ts: ClientTs,
+    /// Shared-secret token presented by the operator.
+    pub admin_token: u64,
+    /// Halt / resume.
+    pub state: KillSwitchState,
+}
+
+/// Decode `KillSwitchSet` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or unknown `state`.
+pub fn parse(payload: &[u8]) -> Result<KillSwitchSet, WireError> {
+    let w = KillSwitchSetWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    for (i, byte) in pad.iter().enumerate() {
+        if *byte != 0 {
+            return Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + i));
+        }
+    }
+    let state = KillSwitchState::try_from(w.state)?;
+    Ok(KillSwitchSet {
+        client_ts: ClientTs::new({ w.client_ts } as i64),
+        admin_token: { w.admin_token },
+        state,
+    })
+}
+
+/// Encode `KillSwitchSet` into a payload buffer.
+pub fn encode(msg: &KillSwitchSet, out: &mut Vec<u8>) {
+    let w = KillSwitchSetWire {
+        client_ts: msg.client_ts.as_nanos() as u64,
+        admin_token: msg.admin_token,
+        state: msg.state.as_u8(),
+        _pad0: [0; 7],
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(state: KillSwitchState) -> KillSwitchSet {
+        KillSwitchSet {
+            client_ts: ClientTs::new(0),
+            admin_token: 0xDEADBEEF,
+            state,
+        }
+    }
+
+    #[test]
+    fn test_kill_switch_wire_size_is_24() {
+        assert_eq!(SIZE, 24);
+    }
+
+    #[test]
+    fn test_kill_switch_halt_roundtrip() {
+        let msg = sample(KillSwitchState::Halt);
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_kill_switch_resume_roundtrip() {
+        let msg = sample(KillSwitchState::Resume);
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_kill_switch_unknown_state_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(KillSwitchState::Halt), &mut buf);
+        buf[16] = 0x05; // state field
+        assert_eq!(parse(&buf), Err(WireError::UnknownKind(5)));
+    }
+
+    #[test]
+    fn test_kill_switch_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(KillSwitchState::Halt), &mut buf);
+        buf[PAD0_OFFSET_BASE + 3] = 0x42;
+        assert_eq!(
+            parse(&buf),
+            Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + 3))
+        );
+    }
+}

--- a/crates/wire/src/inbound/kill_switch.rs
+++ b/crates/wire/src/inbound/kill_switch.rs
@@ -17,7 +17,7 @@ pub struct KillSwitchSetWire {
     /// Shared-secret token; the engine compares against its admin token.
     pub admin_token: u64,
     /// `0` = resume, `1` = halt. Other values are decoded as
-    /// [`WireError::Domain`] downstream.
+    /// [`WireError::InvalidEnumValue`] with `field = "state"`.
     pub state: u8,
     /// Reserved padding; every byte must be zero.
     pub _pad0: [u8; 7],
@@ -55,7 +55,10 @@ impl TryFrom<u8> for KillSwitchState {
         match v {
             0 => Ok(Self::Resume),
             1 => Ok(Self::Halt),
-            other => Err(WireError::UnknownKind(other)),
+            other => Err(WireError::InvalidEnumValue {
+                field: "state",
+                value: other,
+            }),
         }
     }
 }
@@ -148,11 +151,17 @@ mod tests {
     }
 
     #[test]
-    fn test_kill_switch_unknown_state_returns_err() {
+    fn test_kill_switch_unknown_state_returns_invalid_enum_value() {
         let mut buf = Vec::new();
         encode(&sample(KillSwitchState::Halt), &mut buf);
         buf[16] = 0x05; // state field
-        assert_eq!(parse(&buf), Err(WireError::UnknownKind(5)));
+        assert_eq!(
+            parse(&buf),
+            Err(WireError::InvalidEnumValue {
+                field: "state",
+                value: 5,
+            })
+        );
     }
 
     #[test]

--- a/crates/wire/src/inbound/mass_cancel.rs
+++ b/crates/wire/src/inbound/mass_cancel.rs
@@ -1,0 +1,101 @@
+//! `MassCancel` (kind = 0x04).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{AccountId, ClientTs};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 16 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct MassCancelWire {
+    /// Client-stamped timestamp.
+    pub client_ts: u64,
+    /// Account whose resting orders are cancelled.
+    pub account_id: u32,
+    /// Reserved padding; decoder rejects non-zero.
+    pub _pad0: u32,
+}
+
+const _: () = assert!(core::mem::size_of::<MassCancelWire>() == 16);
+
+const SIZE: usize = core::mem::size_of::<MassCancelWire>();
+const PAD0_OFFSET: usize = 12;
+
+/// Domain-typed `MassCancel`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MassCancel {
+    /// Client-stamped timestamp.
+    pub client_ts: ClientTs,
+    /// Account binding.
+    pub account_id: AccountId,
+}
+
+/// Decode `MassCancel` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<MassCancel, WireError> {
+    let w = MassCancelWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    if pad != 0 {
+        return Err(WireError::NonZeroPad(PAD0_OFFSET));
+    }
+    Ok(MassCancel {
+        client_ts: ClientTs::new({ w.client_ts } as i64),
+        account_id: AccountId::new(w.account_id).map_err(to_wire)?,
+    })
+}
+
+/// Encode `MassCancel` into a payload buffer.
+pub fn encode(msg: &MassCancel, out: &mut Vec<u8>) {
+    let w = MassCancelWire {
+        client_ts: msg.client_ts.as_nanos() as u64,
+        account_id: msg.account_id.as_raw(),
+        _pad0: 0,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> MassCancel {
+        MassCancel {
+            client_ts: ClientTs::new(0),
+            account_id: AccountId::new(9).expect("ok"),
+        }
+    }
+
+    #[test]
+    fn test_mass_cancel_wire_size_is_16() {
+        assert_eq!(SIZE, 16);
+    }
+
+    #[test]
+    fn test_mass_cancel_roundtrip() {
+        let msg = sample();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_mass_cancel_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_mass_cancel_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(), &mut buf);
+        buf[PAD0_OFFSET] = 0x77;
+        assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+}

--- a/crates/wire/src/inbound/mod.rs
+++ b/crates/wire/src/inbound/mod.rs
@@ -1,0 +1,61 @@
+//! Inbound (client → engine) message types.
+//!
+//! Each submodule exposes a `parse(payload: &[u8]) -> Result<X, WireError>`
+//! and `encode(msg: &X, out: &mut Vec<u8>)` pair plus the
+//! `XxxWire` `#[repr(C, packed)]` layout struct.
+//!
+//! [`Inbound`] is the dispatched union the gateway hands to the engine.
+
+pub mod cancel_order;
+pub mod cancel_replace;
+pub mod kill_switch;
+pub mod mass_cancel;
+pub mod new_order;
+pub mod snapshot_request;
+
+pub use cancel_order::CancelOrder;
+pub use cancel_replace::CancelReplace;
+pub use kill_switch::{KillSwitchSet, KillSwitchState};
+pub use mass_cancel::MassCancel;
+pub use new_order::NewOrder;
+pub use snapshot_request::SnapshotRequest;
+
+use crate::WireError;
+use crate::framing::{Frame, MessageKind};
+
+/// Tagged union of every inbound message after wire decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Inbound {
+    /// `NewOrder` — limit or market order entry.
+    NewOrder(NewOrder),
+    /// `CancelOrder` — explicit cancel of a resting order.
+    CancelOrder(CancelOrder),
+    /// `CancelReplace` — modify a resting order in place.
+    CancelReplace(CancelReplace),
+    /// `MassCancel` — cancel every resting order on an account.
+    MassCancel(MassCancel),
+    /// `KillSwitchSet` — admin halt / resume of the engine.
+    KillSwitchSet(KillSwitchSet),
+    /// `SnapshotRequest` — operator dump of book + engine state.
+    SnapshotRequest(SnapshotRequest),
+}
+
+/// Parse an inbound frame into its typed variant.
+///
+/// # Errors
+/// Propagates any [`WireError`] from the per-message decoder.
+#[inline]
+pub fn parse_frame(frame: Frame<'_>) -> Result<Inbound, WireError> {
+    match frame.kind {
+        MessageKind::NewOrder => new_order::parse(frame.payload).map(Inbound::NewOrder),
+        MessageKind::CancelOrder => cancel_order::parse(frame.payload).map(Inbound::CancelOrder),
+        MessageKind::CancelReplace => {
+            cancel_replace::parse(frame.payload).map(Inbound::CancelReplace)
+        }
+        MessageKind::MassCancel => mass_cancel::parse(frame.payload).map(Inbound::MassCancel),
+        MessageKind::KillSwitchSet => kill_switch::parse(frame.payload).map(Inbound::KillSwitchSet),
+        MessageKind::SnapshotRequest => {
+            snapshot_request::parse(frame.payload).map(Inbound::SnapshotRequest)
+        }
+    }
+}

--- a/crates/wire/src/inbound/new_order.rs
+++ b/crates/wire/src/inbound/new_order.rs
@@ -1,0 +1,195 @@
+//! `NewOrder` (kind = 0x01).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{AccountId, ClientTs, OrderId, OrderType, Price, Qty, Side, Tif};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 40 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct NewOrderWire {
+    /// Client-stamped timestamp; ns since the documented epoch.
+    pub client_ts: u64,
+    /// Client-assigned non-zero `order_id`.
+    pub order_id: u64,
+    /// Account binding, non-zero.
+    pub account_id: u32,
+    /// `Side` discriminant.
+    pub side: u8,
+    /// `OrderType` discriminant.
+    pub order_type: u8,
+    /// `Tif` discriminant.
+    pub tif: u8,
+    /// Reserved padding; decoder rejects non-zero.
+    pub _pad0: u8,
+    /// Limit price in ticks; ignored when `order_type = Market`.
+    pub price: i64,
+    /// Quantity in lots; `> 0`.
+    pub qty: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<NewOrderWire>() == 40);
+
+const NEW_ORDER_SIZE: usize = core::mem::size_of::<NewOrderWire>();
+const PAD0_OFFSET: usize = 23;
+
+/// Domain-typed `NewOrder` after decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewOrder {
+    /// Client-stamped timestamp.
+    pub client_ts: ClientTs,
+    /// Client-assigned identifier.
+    pub order_id: OrderId,
+    /// Account binding.
+    pub account_id: AccountId,
+    /// Buy / sell.
+    pub side: Side,
+    /// Limit / Market.
+    pub order_type: OrderType,
+    /// Time-in-force policy.
+    pub tif: Tif,
+    /// Limit price; `None` for market orders.
+    pub price: Option<Price>,
+    /// Order quantity.
+    pub qty: Qty,
+}
+
+/// Decode `NewOrder` from a raw payload (no frame header).
+///
+/// # Errors
+/// Returns [`WireError`] on size mismatch, non-zero pad, or domain
+/// validation failure.
+pub fn parse(payload: &[u8]) -> Result<NewOrder, WireError> {
+    let w = NewOrderWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: NEW_ORDER_SIZE,
+        got: payload.len(),
+    })?;
+
+    // Reads from packed fields must copy into a local first.
+    let pad = { w._pad0 };
+    if pad != 0 {
+        return Err(WireError::NonZeroPad(PAD0_OFFSET));
+    }
+
+    let client_ts = ClientTs::new({ w.client_ts } as i64);
+    let order_id = OrderId::new(w.order_id).map_err(to_wire)?;
+    let account_id = AccountId::new(w.account_id).map_err(to_wire)?;
+    let side = Side::try_from(w.side).map_err(to_wire)?;
+    let order_type = OrderType::try_from(w.order_type).map_err(to_wire)?;
+    let tif = Tif::try_from(w.tif).map_err(to_wire)?;
+    let qty = Qty::new(w.qty).map_err(to_wire)?;
+
+    let price = match order_type {
+        OrderType::Market => None,
+        OrderType::Limit => Some(Price::new(w.price).map_err(to_wire)?),
+    };
+
+    Ok(NewOrder {
+        client_ts,
+        order_id,
+        account_id,
+        side,
+        order_type,
+        tif,
+        price,
+        qty,
+    })
+}
+
+/// Encode `NewOrder` into a payload buffer.
+pub fn encode(msg: &NewOrder, out: &mut Vec<u8>) {
+    let w = NewOrderWire {
+        client_ts: msg.client_ts.as_nanos() as u64,
+        order_id: msg.order_id.as_raw(),
+        account_id: msg.account_id.as_raw(),
+        side: msg.side.as_u8(),
+        order_type: msg.order_type.as_u8(),
+        tif: msg.tif.as_u8(),
+        _pad0: 0,
+        price: msg.price.map(Price::as_ticks).unwrap_or(0),
+        qty: msg.qty.as_lots(),
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_limit() -> NewOrder {
+        NewOrder {
+            client_ts: ClientTs::new(1_700_000_000_000_000_000),
+            order_id: OrderId::new(42).expect("ok"),
+            account_id: AccountId::new(7).expect("ok"),
+            side: Side::Bid,
+            order_type: OrderType::Limit,
+            tif: Tif::Gtc,
+            price: Some(Price::new(100).expect("ok")),
+            qty: Qty::new(5).expect("ok"),
+        }
+    }
+
+    fn sample_market() -> NewOrder {
+        NewOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(1).expect("ok"),
+            account_id: AccountId::new(1).expect("ok"),
+            side: Side::Ask,
+            order_type: OrderType::Market,
+            tif: Tif::Ioc,
+            price: None,
+            qty: Qty::new(10).expect("ok"),
+        }
+    }
+
+    #[test]
+    fn test_new_order_wire_size_is_40() {
+        assert_eq!(core::mem::size_of::<NewOrderWire>(), 40);
+    }
+
+    #[test]
+    fn test_new_order_limit_roundtrip() {
+        let msg = sample_limit();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        let decoded = parse(&buf).expect("decode");
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn test_new_order_market_decodes_with_none_price() {
+        let msg = sample_market();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        let decoded = parse(&buf).expect("decode");
+        assert!(decoded.price.is_none());
+        assert_eq!(decoded.order_type, OrderType::Market);
+    }
+
+    #[test]
+    fn test_new_order_truncated_returns_payload_size_error() {
+        let buf = [0u8; NEW_ORDER_SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_new_order_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_limit(), &mut buf);
+        buf[PAD0_OFFSET] = 0xFF;
+        assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+
+    #[test]
+    fn test_new_order_zero_order_id_returns_domain_err() {
+        let mut buf = Vec::new();
+        encode(&sample_limit(), &mut buf);
+        // overwrite order_id (offset 8) with zero
+        for byte in &mut buf[8..16] {
+            *byte = 0;
+        }
+        assert!(matches!(parse(&buf), Err(WireError::Domain(_))));
+    }
+}

--- a/crates/wire/src/inbound/snapshot_request.rs
+++ b/crates/wire/src/inbound/snapshot_request.rs
@@ -1,0 +1,93 @@
+//! `SnapshotRequest` (kind = 0x06).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::WireError;
+
+/// Wire layout — `#[repr(C, packed)]`, 16 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct SnapshotRequestWire {
+    /// Operator-assigned correlation id; echoed in `SnapshotResponse`.
+    pub request_id: u64,
+    /// Reserved padding; every byte must be zero.
+    pub _pad0: [u8; 8],
+}
+
+const _: () = assert!(core::mem::size_of::<SnapshotRequestWire>() == 16);
+
+const SIZE: usize = core::mem::size_of::<SnapshotRequestWire>();
+const PAD0_OFFSET_BASE: usize = 8;
+
+/// Domain-typed `SnapshotRequest`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRequest {
+    /// Operator-assigned correlation id.
+    pub request_id: u64,
+}
+
+/// Decode `SnapshotRequest` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch or non-zero padding.
+pub fn parse(payload: &[u8]) -> Result<SnapshotRequest, WireError> {
+    let w = SnapshotRequestWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    for (i, byte) in pad.iter().enumerate() {
+        if *byte != 0 {
+            return Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + i));
+        }
+    }
+    Ok(SnapshotRequest {
+        request_id: { w.request_id },
+    })
+}
+
+/// Encode `SnapshotRequest` into a payload buffer.
+pub fn encode(msg: &SnapshotRequest, out: &mut Vec<u8>) {
+    let w = SnapshotRequestWire {
+        request_id: msg.request_id,
+        _pad0: [0; 8],
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snapshot_request_wire_size_is_16() {
+        assert_eq!(SIZE, 16);
+    }
+
+    #[test]
+    fn test_snapshot_request_roundtrip() {
+        let msg = SnapshotRequest {
+            request_id: 0xCAFEBABE,
+        };
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_snapshot_request_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_snapshot_request_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&SnapshotRequest { request_id: 1 }, &mut buf);
+        buf[PAD0_OFFSET_BASE + 5] = 0xAA;
+        assert_eq!(
+            parse(&buf),
+            Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + 5))
+        );
+    }
+}

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -15,9 +15,19 @@
 //! - `KillSwitchSet` (0x05)
 //! - `SnapshotRequest` (0x06)
 //!
-//! Outbound message kinds (issue #5) live behind `crate::outbound`.
+//! Outbound message kinds (issue #5) will live behind a future
+//! `crate::outbound` module.
 
 #![warn(missing_docs)]
+
+// The wire format is little-endian by design (skill / `docs/protocol.md`).
+// Compile-fail on big-endian targets so a packed payload encoded on a
+// BE host never silently decodes back as endian-swapped garbage.
+#[cfg(not(target_endian = "little"))]
+compile_error!(
+    "hft-clob-core wire format is little-endian; \
+     `target_endian = \"big\"` is unsupported"
+);
 
 pub mod error;
 pub mod framing;

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -1,8 +1,31 @@
-//! Binary wire protocol — SBE-based schema, encoders, decoders.
+//! Binary wire protocol — bespoke, fixed-size, little-endian.
 //!
-//! Defines the on-wire message format for order entry (inbound) and
-//! market data / execution reports (outbound). Uses IronSBE for zero-copy
-//! schema and code generation. All lengths are little-endian; framing is
-//! length-prefixed TCP (first 4 bytes = message length in bytes).
+//! This crate is a pure codec. It does not import `tokio` or any
+//! transport library; the gateway feeds it `&[u8]` slices and consumes
+//! `Vec<u8>` writes. See `docs/protocol.md` for the on-wire layout
+//! tables — the prose there is the single source of truth and any
+//! encoder change must update both files in the same commit.
 //!
-//! Roundtrip tests will verify encode → decode preserves all fields byte-identically (issue #5).
+//! Inbound message kinds (this crate, issue #4):
+//!
+//! - `NewOrder` (0x01)
+//! - `CancelOrder` (0x02)
+//! - `CancelReplace` (0x03)
+//! - `MassCancel` (0x04)
+//! - `KillSwitchSet` (0x05)
+//! - `SnapshotRequest` (0x06)
+//!
+//! Outbound message kinds (issue #5) live behind `crate::outbound`.
+
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod framing;
+pub mod inbound;
+
+pub use error::WireError;
+pub use framing::{FRAME_HEADER_BYTES, FRAME_KIND_BYTES, FRAME_LEN_BYTES, Frame, MessageKind};
+
+/// Wire-protocol version. Bump on any layout change to inbound or
+/// outbound message bodies.
+pub const WIRE_VERSION: u16 = 1;

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,114 @@
+# Wire Protocol
+
+Single source of truth for the on-wire format of `hft-clob-core`. Any
+encoder or decoder change must update this document in the same commit.
+
+## Design constants
+
+| Constant         | Value                                              |
+|------------------|----------------------------------------------------|
+| Endianness       | little-endian (target is x86_64; avoids per-field byte swaps on the hot path) |
+| Framing          | `len: u32 \| kind: u8 \| payload: [u8; len - 1]`   |
+| Alignment        | packed (`#[repr(C, packed)]`); decoder rejects non-zero padding |
+| Strings          | not used; all identifiers are fixed-width integers |
+| Timestamps       | `u64` nanoseconds (carried opaque on the wire; the matching engine never reads them for control flow) |
+| Price / Qty      | `i64` ticks / `u64` lots; see `domain::consts::{TICK_SIZE, LOT_SIZE}` |
+| Wire version     | `WIRE_VERSION = 1`. Bump on any layout change      |
+
+The `len` field counts bytes from the `kind` byte through the end of the
+payload (i.e. `len = 1 + payload.len()`). A frame is therefore `4 + len`
+bytes total. Decoders that encounter an unknown `kind` advance `len`
+bytes and continue.
+
+## Message-kind table
+
+| Kind | Hex   | Direction | Name              | Size (kind + payload) |
+|------|-------|-----------|-------------------|-----------------------|
+| 1    | 0x01  | inbound   | `NewOrder`        | 41 bytes              |
+| 2    | 0x02  | inbound   | `CancelOrder`     | 25 bytes              |
+| 3    | 0x03  | inbound   | `CancelReplace`   | 41 bytes              |
+| 4    | 0x04  | inbound   | `MassCancel`      | 17 bytes              |
+| 5    | 0x05  | inbound   | `KillSwitchSet`   | 25 bytes              |
+| 6    | 0x06  | inbound   | `SnapshotRequest` | 17 bytes              |
+
+Outbound message kinds (templateIds 101..) land in issue #5.
+
+## Inbound layouts
+
+### `NewOrder` (kind = 0x01)
+
+| Offset | Size | Field        | Type | Notes                                  |
+|-------:|-----:|--------------|------|----------------------------------------|
+| 0      | 8    | `client_ts`  | u64  | nanoseconds; opaque to the engine      |
+| 8      | 8    | `order_id`   | u64  | client-assigned, non-zero, unique/acct |
+| 16     | 4    | `account_id` | u32  | non-zero                               |
+| 20     | 1    | `side`       | u8   | `1 = Bid`, `2 = Ask`                   |
+| 21     | 1    | `order_type` | u8   | `1 = Limit`, `2 = Market`              |
+| 22     | 1    | `tif`        | u8   | `1 = GTC`, `2 = IOC`, `3 = POST_ONLY`  |
+| 23     | 1    | `_pad0`      | u8   | zero; reserved                         |
+| 24     | 8    | `price`      | i64  | ticks; ignored when `order_type = Market` |
+| 32     | 8    | `qty`        | u64  | lots; > 0                              |
+| —      | 40   | **total**    |      |                                        |
+
+### `CancelOrder` (kind = 0x02)
+
+| Offset | Size | Field        | Type | Notes                  |
+|-------:|-----:|--------------|------|------------------------|
+| 0      | 8    | `client_ts`  | u64  |                        |
+| 8      | 8    | `order_id`   | u64  | non-zero               |
+| 16     | 4    | `account_id` | u32  | non-zero               |
+| 20     | 4    | `_pad0`      | u32  | zero                   |
+| —      | 24   | **total**    |      |                        |
+
+### `CancelReplace` (kind = 0x03)
+
+| Offset | Size | Field        | Type | Notes                                |
+|-------:|-----:|--------------|------|--------------------------------------|
+| 0      | 8    | `client_ts`  | u64  |                                      |
+| 8      | 8    | `order_id`   | u64  | resting order to be replaced         |
+| 16     | 4    | `account_id` | u32  | must own `order_id`                  |
+| 20     | 4    | `_pad0`      | u32  | zero                                 |
+| 24     | 8    | `new_price`  | i64  | ticks                                |
+| 32     | 8    | `new_qty`    | u64  | lots; `> 0`                          |
+| —      | 40   | **total**    |      |                                      |
+
+Priority semantics (per `doc/DESIGN.md` § 5.3): price change → new
+priority; qty up → new priority; qty down → in-place, priority preserved.
+
+### `MassCancel` (kind = 0x04)
+
+| Offset | Size | Field        | Type | Notes                  |
+|-------:|-----:|--------------|------|------------------------|
+| 0      | 8    | `client_ts`  | u64  |                        |
+| 8      | 4    | `account_id` | u32  | cancels every resting order on this account |
+| 12     | 4    | `_pad0`      | u32  | zero                   |
+| —      | 16   | **total**    |      |                        |
+
+### `KillSwitchSet` (kind = 0x05)
+
+| Offset | Size | Field          | Type    | Notes                  |
+|-------:|-----:|----------------|---------|------------------------|
+| 0      | 8    | `client_ts`    | u64     |                        |
+| 8      | 8    | `admin_token`  | u64     | shared-secret check    |
+| 16     | 1    | `state`        | u8      | `0 = resume`, `1 = halt` |
+| 17     | 7    | `_pad0`        | [u8; 7] | all zero               |
+| —      | 24   | **total**      |         |                        |
+
+### `SnapshotRequest` (kind = 0x06)
+
+| Offset | Size | Field         | Type    | Notes                  |
+|-------:|-----:|---------------|---------|------------------------|
+| 0      | 8    | `request_id`  | u64     | echoed in the response |
+| 8      | 8    | `_pad0`       | [u8; 8] | all zero               |
+| —      | 16   | **total**     |         |                        |
+
+## Decode invariants
+
+- Frame length must be exactly `4 + len` bytes; truncation returns
+  `WireError::Truncated`.
+- `kind` byte must match an assigned discriminant; otherwise
+  `WireError::UnknownKind(byte)`.
+- Every `_pad*` byte must be zero; otherwise
+  `WireError::NonZeroPad(offset)`.
+- Each integer field is parsed into its corresponding `domain::` newtype
+  at the boundary; validation failures surface as `WireError::Domain(_)`.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -7,18 +7,34 @@ encoder or decoder change must update this document in the same commit.
 
 | Constant         | Value                                              |
 |------------------|----------------------------------------------------|
-| Endianness       | little-endian (target is x86_64; avoids per-field byte swaps on the hot path) |
+| Endianness       | little-endian (target is x86_64; avoids per-field byte swaps on the hot path). Enforced at compile time — `crates/wire/src/lib.rs` carries a `compile_error!` on `target_endian = "big"` |
 | Framing          | `len: u32 \| kind: u8 \| payload: [u8; len - 1]`   |
 | Alignment        | packed (`#[repr(C, packed)]`); decoder rejects non-zero padding |
 | Strings          | not used; all identifiers are fixed-width integers |
-| Timestamps       | `u64` nanoseconds (carried opaque on the wire; the matching engine never reads them for control flow) |
+| Timestamps       | wire-level `u64` nanoseconds; carried opaque, the matching engine never reads them for control flow |
 | Price / Qty      | `i64` ticks / `u64` lots; see `domain::consts::{TICK_SIZE, LOT_SIZE}` |
 | Wire version     | `WIRE_VERSION = 1`. Bump on any layout change      |
 
 The `len` field counts bytes from the `kind` byte through the end of the
 payload (i.e. `len = 1 + payload.len()`). A frame is therefore `4 + len`
 bytes total. Decoders that encounter an unknown `kind` advance `len`
-bytes and continue.
+bytes and continue — see `Frame::parse_or_skip` in `crates/wire/src/framing.rs`.
+
+### Timestamp representation
+
+The wire field is `u64`. The corresponding domain newtypes
+(`domain::ClientTs`, `domain::RecvTs`) are `i64`. Encode and decode
+perform a bit-preserving `as` cast between the two:
+
+- Encode: `i64 as u64` reinterprets the two's-complement bits.
+- Decode: `u64 as i64` reinterprets the same bits back.
+
+A negative `i64` timestamp therefore encodes as a `u64` value above
+`i64::MAX`. The cast is lossless and the roundtrip is byte-identical.
+The matching core never reads the value for control flow, so the
+signed / unsigned interpretation is irrelevant beyond storage; clients
+that read the wire as `u64` and the engine that reads it as `i64`
+agree on every bit.
 
 ## Message-kind table
 


### PR DESCRIPTION
## Summary

Establish the on-wire format with a bespoke fixed-size little-endian encoding (`zerocopy::FromBytes` / `IntoBytes`) for the six inbound messages: `NewOrder`, `CancelOrder`, `CancelReplace`, `MassCancel`, `KillSwitchSet`, `SnapshotRequest`. Layout / framing / endianness / decode invariants are documented in [`docs/protocol.md`](docs/protocol.md) — single source of truth.

## Changes

- `crates/wire/src/framing.rs` — `Frame::parse` / `Frame::write`, `MessageKind` enum (kinds 0x01..0x06), `FRAME_HEADER_BYTES`.
- `crates/wire/src/error.rs` — `WireError` thiserror enum: `Truncated`, `UnknownKind(u8)`, `NonZeroPad(usize)`, `PayloadSize { expected, got }`, `Domain(#[from] DomainError)`.
- `crates/wire/src/inbound/{new_order,cancel_order,cancel_replace,mass_cancel,kill_switch,snapshot_request}.rs` — one module per message: `#[repr(C, packed)]` wire struct, domain-typed struct, `parse(&[u8]) -> Result<X, WireError>`, `encode(&X, &mut Vec<u8>)`.
- `crates/wire/src/inbound/mod.rs` — `Inbound` tagged union + `parse_frame(Frame) -> Result<Inbound, WireError>` dispatcher.
- `docs/protocol.md` — full layout tables.
- `README.md` — wire-protocol section pointing at the doc.
- Workspace `Cargo.toml` adds `zerocopy = "0.8"`.
- `crates/wire/Cargo.toml` swaps `ironsbe-*` + `bytes` for `thiserror` + `zerocopy`.

## Technical decisions

**Bespoke `#[repr(C, packed)]` + zerocopy instead of ironsbe-codegen.** The issue body's wording leaned on `ironsbe-codegen` to drive code generation from an XML SBE schema. Mid-implementation the project's `wire-protocol` skill (binding source-of-truth on layout / framing / codec) was inspected and prescribes the bespoke approach — packed structs + zerocopy + manual offset table in `docs/protocol.md`. Going via SBE codegen would have required hand-writing an SBE XML schema without an upstream template plus a build.rs integration: 3-4× the work for the same guarantees this PR already delivers (real binary protocol, fixed-size, documented layout, byte-identical roundtrip in unit tests). The IronSBE crates.io dep stays available in workspace deps for any future schema-driven path without blocking this milestone.

**Frame layout.** `[len: u32 LE | kind: u8 | payload: [u8; len - 1]]`. `len` includes the `kind` byte. Decoders that encounter an unknown kind advance `len` bytes and continue.

**Padding bytes.** Every reserved `_padN` byte is rejected when non-zero. Catches malformed or version-mismatched payloads early.

**Domain conversion at the boundary.** Wire structs use raw `u64` / `i64` / `u8`. The per-message `parse` fn converts every integer field into its `domain::` newtype via `try_from` / `new`, lifting failures to `WireError::Domain(_)` through a `to_wire` helper. The matching core never sees a raw integer.

**`KillSwitchState` enum lives in this crate**, not in `domain`, because it is a wire-only payload (the engine has its own internal `bool kill_switch` state, not this enum).

**Outbound + roundtrip proptest matrix** are explicitly out of scope here and land in #5 alongside the outbound encoder.

## Public API impact

New public surface re-exported from `wire::`:

```rust
pub use error::WireError;
pub use framing::{Frame, MessageKind, FRAME_HEADER_BYTES, FRAME_KIND_BYTES, FRAME_LEN_BYTES};
pub mod inbound; // all 6 message modules + Inbound enum + parse_frame
pub const WIRE_VERSION: u16 = 1;
```

## Determinism / hot-path

The parse path is on the gateway → engine hot path eventually. No allocations after warmup once `Vec` reuse arrives in #13. No async, no `tracing` in this crate — pure codec.

`#[repr(C, packed)]` field reads use the canonical `let copy = w.field;` pattern (or rely on rustc's modern auto-handling for `Copy` fields) so we never take a reference to a misaligned location. `cargo clippy --all-targets -- -D warnings` would catch a slip.

## Testing

- 32 unit tests across the wire crate (size assertion + roundtrip + truncated + non-zero-pad + domain-error per message, plus framing edge cases).
- Combined workspace: 75 passed; 0 failed.

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 75 passed; 0 failed
- [x] `cargo build --release` clean
- [x] `cargo build -p wire` clean

## Checklist

- [x] No `tokio` / `ironsbe-transport` deps in `crates/wire/`
- [x] `WireError` is a closed `thiserror` enum — no bare strings
- [x] Each inbound message has `parse(&[u8]) -> Result<X, WireError>`
- [x] `WIRE_VERSION = 1` documented in `lib.rs`
- [x] No `.unwrap()` / `.expect()` / unchecked `[]` indexing in production code
- [x] Module boundaries respected — depends on `domain` only
- [x] No new dependencies beyond `zerocopy` (added to workspace deps; no allocator / time / rand surface)
- [x] `#[repr(transparent)]` not applicable (these are `#[repr(C, packed)]` wire layouts; domain newtypes already use `transparent`)
- [x] `#[must_use]` / `#[inline]` placed where appropriate

Closes #4