### PR TITLE
Outbound wire codec + roundtrip proptest matrix (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,18 @@ encoders, decoders, and roundtrip tests.
 | 5    | 0x05  | `KillSwitchSet`   | 24 bytes     | Admin halt / resume                 |
 | 6    | 0x06  | `SnapshotRequest` | 16 bytes     | Operator dump of book + engine state |
 
-Outbound message kinds (101+) land in #5.
+### Outbound message kinds
+
+| Kind | Hex   | Name                | Payload size | Purpose                                            |
+|------|-------|---------------------|--------------|----------------------------------------------------|
+| 101  | 0x65  | `ExecReport`        | 64 bytes     | Order lifecycle transition (accepted, rejected, (partially) filled, cancelled, replaced) |
+| 102  | 0x66  | `TradePrint`        | 48 bytes     | Public trade emission                              |
+| 103  | 0x67  | `BookUpdateTop`     | 48 bytes     | Top-of-book on every book change                   |
+| 104  | 0x68  | `BookUpdateL2Delta` | 40 bytes     | Per-level depth delta (level removed when `new_qty = 0`) |
+
+`SnapshotResponse` (105) is intentionally absent from the bespoke
+fixed-size pattern; the variable-length book depth array lives behind a
+separate framing scheme to be added under a later issue.
 
 ### Decode invariants
 

--- a/crates/domain/src/error.rs
+++ b/crates/domain/src/error.rs
@@ -8,8 +8,8 @@
 use thiserror::Error;
 
 use crate::types::{
-    AccountIdError, CancelReasonError, EngineSeqError, OrderIdError, OrderTypeError, PriceError,
-    QtyError, RejectReasonError, SideError, TifError, TradeIdError,
+    AccountIdError, CancelReasonError, EngineSeqError, ExecStateError, OrderIdError,
+    OrderTypeError, PriceError, QtyError, RejectReasonError, SideError, TifError, TradeIdError,
 };
 
 /// Aggregator over every per-type validation / decode error in the
@@ -50,4 +50,7 @@ pub enum DomainError {
     /// `CancelReason` decode.
     #[error(transparent)]
     CancelReason(#[from] CancelReasonError),
+    /// `ExecState` decode.
+    #[error(transparent)]
+    ExecState(#[from] ExecStateError),
 }

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -27,7 +27,7 @@ pub mod types;
 pub use error::DomainError;
 pub use types::{
     AccountId, AccountIdError, CancelReason, CancelReasonError, ClientTs, EngineSeq,
-    EngineSeqError, OrderId, OrderIdError, OrderType, OrderTypeError, Price, PriceError, Qty,
-    QtyError, RecvTs, RejectReason, RejectReasonError, Side, SideError, Tif, TifError, TradeId,
-    TradeIdError,
+    EngineSeqError, ExecState, ExecStateError, OrderId, OrderIdError, OrderType, OrderTypeError,
+    Price, PriceError, Qty, QtyError, RecvTs, RejectReason, RejectReasonError, Side, SideError,
+    Tif, TifError, TradeId, TradeIdError,
 };

--- a/crates/domain/src/types/exec_state.rs
+++ b/crates/domain/src/types/exec_state.rs
@@ -1,0 +1,130 @@
+//! Execution-report state.
+
+use std::fmt;
+
+/// Lifecycle state carried in every outbound `ExecReport`. Wire-stable:
+/// numeric discriminants are part of the public contract and must not
+/// be reassigned.
+///
+/// State machine (lossy summary; the engine emits a sequence of these
+/// per order):
+///
+/// ```text
+///   ┌─────────┐  reject ┌────────┐
+///   │  ─────  ├────────►│Rejected│           terminal
+///   │         │         └────────┘
+///   │         │  ack    ┌────────┐  fill┌─────────────────┐
+///   │ ingress ├────────►│Accepted├─────►│ PartiallyFilled │─┐
+///   │         │         └────────┘      └─────────────────┘ │
+///   └─────────┘                            │       │        │ fill remainder
+///                                          │       └────────┴►┌──────┐  terminal
+///                                          │                  │Filled│
+///                                          │                  └──────┘
+///                                          │ user / mass / IOC remainder / STP
+///                                          ▼
+///                                       ┌─────────┐
+///                                       │Cancelled│              terminal
+///                                       └─────────┘
+///                                       ┌────────┐
+///                                       │Replaced│   (CancelReplace, terminal for old order)
+///                                       └────────┘
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ExecState {
+    /// Order admitted to the engine; not yet matched.
+    Accepted = 1,
+    /// Order rejected pre-trade; carries a `RejectReason`.
+    Rejected = 2,
+    /// Order partially filled; remaining `leaves_qty` rests or
+    /// continues the walk depending on TIF.
+    PartiallyFilled = 3,
+    /// Order fully filled; terminal.
+    Filled = 4,
+    /// Order cancelled; carries a `CancelReason`. Terminal.
+    Cancelled = 5,
+    /// Order superseded by a `CancelReplace`. Terminal for the old
+    /// `order_id`; the new resting order is reported separately.
+    Replaced = 6,
+}
+
+impl ExecState {
+    /// Numeric discriminant for the wire encoder.
+    #[inline(always)]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for ExecState {
+    type Error = ExecStateError;
+    #[inline]
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(Self::Accepted),
+            2 => Ok(Self::Rejected),
+            3 => Ok(Self::PartiallyFilled),
+            4 => Ok(Self::Filled),
+            5 => Ok(Self::Cancelled),
+            6 => Ok(Self::Replaced),
+            other => Err(ExecStateError::Unknown(other)),
+        }
+    }
+}
+
+impl fmt::Display for ExecState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Decode error for [`ExecState::try_from`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExecStateError {
+    /// Wire payload contained a discriminant outside `1..=6`.
+    #[error("unknown ExecState discriminant: {0}")]
+    Unknown(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for ExecState {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            prop_oneof![
+                Just(Self::Accepted),
+                Just(Self::Rejected),
+                Just(Self::PartiallyFilled),
+                Just(Self::Filled),
+                Just(Self::Cancelled),
+                Just(Self::Replaced),
+            ]
+            .boxed()
+        }
+    }
+
+    #[test]
+    fn test_exec_state_discriminants_are_stable() {
+        assert_eq!(ExecState::Accepted.as_u8(), 1);
+        assert_eq!(ExecState::Replaced.as_u8(), 6);
+    }
+
+    #[test]
+    fn test_exec_state_try_from_unknown_returns_err() {
+        assert_eq!(ExecState::try_from(0), Err(ExecStateError::Unknown(0)));
+        assert_eq!(ExecState::try_from(7), Err(ExecStateError::Unknown(7)));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_exec_state_u8_roundtrip(s in any::<ExecState>()) {
+            prop_assert_eq!(ExecState::try_from(s.as_u8()).expect("roundtrip"), s);
+        }
+    }
+}

--- a/crates/domain/src/types/mod.rs
+++ b/crates/domain/src/types/mod.rs
@@ -11,6 +11,7 @@ mod recv_ts;
 mod trade_id;
 
 mod cancel_reason;
+mod exec_state;
 mod order_type;
 mod reject_reason;
 mod side;
@@ -26,6 +27,7 @@ pub use recv_ts::RecvTs;
 pub use trade_id::{TradeId, TradeIdError};
 
 pub use cancel_reason::{CancelReason, CancelReasonError};
+pub use exec_state::{ExecState, ExecStateError};
 pub use order_type::{OrderType, OrderTypeError};
 pub use reject_reason::{RejectReason, RejectReasonError};
 pub use side::{Side, SideError};

--- a/crates/wire/src/error.rs
+++ b/crates/wire/src/error.rs
@@ -46,6 +46,13 @@ pub enum WireError {
     /// prefix.
     #[error("framed payload size exceeds u32::MAX: {0} bytes")]
     PayloadTooLarge(usize),
+    /// A wire payload decoded into a domain message that violates a
+    /// cross-field invariant — for example an `ExecReport` with
+    /// `state = Accepted` but a non-zero `reject_reason`, or a
+    /// `BookUpdateTop` side where only one of `price` / `qty` is zero.
+    /// The slice carries a short identifier for the failing rule.
+    #[error("inconsistent payload: {0}")]
+    InconsistentPayload(&'static str),
     /// A field failed `domain` validation (e.g. zero `OrderId`,
     /// non-positive `Price`, unknown `Side` discriminant).
     #[error(transparent)]

--- a/crates/wire/src/framing.rs
+++ b/crates/wire/src/framing.rs
@@ -16,8 +16,9 @@ pub const FRAME_KIND_BYTES: usize = 1;
 /// Total header size in bytes: `len` prefix + `kind` byte.
 pub const FRAME_HEADER_BYTES: usize = FRAME_LEN_BYTES + FRAME_KIND_BYTES;
 
-/// Inbound message kind. Numeric discriminants are wire-stable and must
-/// match the table in `docs/protocol.md`.
+/// Wire-level message kind. Numeric discriminants are wire-stable and
+/// must match the table in `docs/protocol.md`. Inbound kinds occupy
+/// `0x01..=0x06`; outbound kinds occupy `0x65..=0x68` (decimal 101..104).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum MessageKind {
@@ -33,6 +34,15 @@ pub enum MessageKind {
     KillSwitchSet = 0x05,
     /// `SnapshotRequest` — operator dump of book + engine state.
     SnapshotRequest = 0x06,
+    /// `ExecReport` — order lifecycle transition (accepted, rejected,
+    /// (partially) filled, cancelled, replaced).
+    ExecReport = 0x65,
+    /// `TradePrint` — public trade emission.
+    TradePrint = 0x66,
+    /// `BookUpdateTop` — top-of-book on every book change.
+    BookUpdateTop = 0x67,
+    /// `BookUpdateL2Delta` — per-level depth delta.
+    BookUpdateL2Delta = 0x68,
 }
 
 impl MessageKind {
@@ -55,6 +65,10 @@ impl TryFrom<u8> for MessageKind {
             0x04 => Ok(Self::MassCancel),
             0x05 => Ok(Self::KillSwitchSet),
             0x06 => Ok(Self::SnapshotRequest),
+            0x65 => Ok(Self::ExecReport),
+            0x66 => Ok(Self::TradePrint),
+            0x67 => Ok(Self::BookUpdateTop),
+            0x68 => Ok(Self::BookUpdateL2Delta),
             other => Err(WireError::UnknownKind(other)),
         }
     }

--- a/crates/wire/src/inbound/mod.rs
+++ b/crates/wire/src/inbound/mod.rs
@@ -43,7 +43,10 @@ pub enum Inbound {
 /// Parse an inbound frame into its typed variant.
 ///
 /// # Errors
-/// Propagates any [`WireError`] from the per-message decoder.
+/// Propagates any [`WireError`] from the per-message decoder. Returns
+/// [`WireError::UnknownKind`] when the frame carries an outbound kind
+/// (those discriminants are valid in [`MessageKind`] but not legal on
+/// the inbound stream).
 #[inline]
 pub fn parse_frame(frame: Frame<'_>) -> Result<Inbound, WireError> {
     match frame.kind {
@@ -57,5 +60,9 @@ pub fn parse_frame(frame: Frame<'_>) -> Result<Inbound, WireError> {
         MessageKind::SnapshotRequest => {
             snapshot_request::parse(frame.payload).map(Inbound::SnapshotRequest)
         }
+        outbound @ (MessageKind::ExecReport
+        | MessageKind::TradePrint
+        | MessageKind::BookUpdateTop
+        | MessageKind::BookUpdateL2Delta) => Err(WireError::UnknownKind(outbound.as_u8())),
     }
 }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -15,8 +15,12 @@
 //! - `KillSwitchSet` (0x05)
 //! - `SnapshotRequest` (0x06)
 //!
-//! Outbound message kinds (issue #5) will live behind a future
-//! `crate::outbound` module.
+//! Outbound message kinds (this crate, issue #5):
+//!
+//! - `ExecReport` (0x65)
+//! - `TradePrint` (0x66)
+//! - `BookUpdateTop` (0x67)
+//! - `BookUpdateL2Delta` (0x68)
 
 #![warn(missing_docs)]
 
@@ -32,6 +36,7 @@ compile_error!(
 pub mod error;
 pub mod framing;
 pub mod inbound;
+pub mod outbound;
 
 pub use error::WireError;
 pub use framing::{FRAME_HEADER_BYTES, FRAME_KIND_BYTES, FRAME_LEN_BYTES, Frame, MessageKind};

--- a/crates/wire/src/outbound/book_update_l2_delta.rs
+++ b/crates/wire/src/outbound/book_update_l2_delta.rs
@@ -1,0 +1,157 @@
+//! `BookUpdateL2Delta` (kind = 0x68 / 104).
+//!
+//! Per-level depth delta. `new_qty == 0` is the wire sentinel for
+//! "level removed"; non-zero is the new aggregate qty at that level.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{EngineSeq, Price, Qty, RecvTs, Side};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 40 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct BookUpdateL2DeltaWire {
+    /// Strictly monotonic engine sequence number.
+    pub engine_seq: u64,
+    /// Level price in ticks.
+    pub price: i64,
+    /// New aggregate qty at this level in lots; `0` means the level
+    /// has been removed.
+    pub new_qty: u64,
+    /// `Side` discriminant.
+    pub side: u8,
+    /// Reserved padding; every byte must be zero.
+    pub _pad0: [u8; 7],
+    /// Engine emit timestamp.
+    pub emit_ts: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<BookUpdateL2DeltaWire>() == 40);
+
+const SIZE: usize = core::mem::size_of::<BookUpdateL2DeltaWire>();
+const PAD0_OFFSET_BASE: usize = 25;
+
+/// Domain-typed `BookUpdateL2Delta`. `new_qty == None` corresponds to
+/// "level removed".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BookUpdateL2Delta {
+    /// Engine-assigned sequence number.
+    pub engine_seq: EngineSeq,
+    /// Level price.
+    pub price: Price,
+    /// New aggregate qty at this level; `None` means the level has
+    /// been removed.
+    pub new_qty: Option<Qty>,
+    /// Side that the level lives on.
+    pub side: Side,
+    /// Engine emit timestamp.
+    pub emit_ts: RecvTs,
+}
+
+/// Decode `BookUpdateL2Delta` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<BookUpdateL2Delta, WireError> {
+    let w = BookUpdateL2DeltaWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    for (i, byte) in pad.iter().enumerate() {
+        if *byte != 0 {
+            return Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + i));
+        }
+    }
+    let new_qty = if w.new_qty != 0 {
+        Some(Qty::new(w.new_qty).map_err(to_wire)?)
+    } else {
+        None
+    };
+    Ok(BookUpdateL2Delta {
+        engine_seq: EngineSeq::new(w.engine_seq),
+        price: Price::new(w.price).map_err(to_wire)?,
+        new_qty,
+        side: Side::try_from(w.side).map_err(to_wire)?,
+        emit_ts: RecvTs::new(w.emit_ts as i64),
+    })
+}
+
+/// Encode `BookUpdateL2Delta` into a payload buffer.
+pub fn encode(msg: &BookUpdateL2Delta, out: &mut Vec<u8>) {
+    let w = BookUpdateL2DeltaWire {
+        engine_seq: msg.engine_seq.as_raw(),
+        price: msg.price.as_ticks(),
+        new_qty: msg.new_qty.map(Qty::as_lots).unwrap_or(0),
+        side: msg.side.as_u8(),
+        _pad0: [0; 7],
+        emit_ts: msg.emit_ts.as_nanos() as u64,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_present() -> BookUpdateL2Delta {
+        BookUpdateL2Delta {
+            engine_seq: EngineSeq::new(200),
+            price: Price::new(50).expect("ok"),
+            new_qty: Some(Qty::new(13).expect("ok")),
+            side: Side::Bid,
+            emit_ts: RecvTs::new(1_500_000),
+        }
+    }
+
+    fn sample_removed() -> BookUpdateL2Delta {
+        BookUpdateL2Delta {
+            engine_seq: EngineSeq::new(201),
+            price: Price::new(60).expect("ok"),
+            new_qty: None,
+            side: Side::Ask,
+            emit_ts: RecvTs::new(1_500_001),
+        }
+    }
+
+    #[test]
+    fn test_book_update_l2_delta_wire_size_is_40() {
+        assert_eq!(SIZE, 40);
+    }
+
+    #[test]
+    fn test_book_update_l2_delta_present_roundtrip() {
+        let msg = sample_present();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_book_update_l2_delta_removed_decodes_with_none_qty() {
+        let msg = sample_removed();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        let decoded = parse(&buf).expect("decode");
+        assert!(decoded.new_qty.is_none());
+    }
+
+    #[test]
+    fn test_book_update_l2_delta_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_book_update_l2_delta_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_present(), &mut buf);
+        buf[PAD0_OFFSET_BASE + 2] = 0xAA;
+        assert_eq!(
+            parse(&buf),
+            Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + 2))
+        );
+    }
+}

--- a/crates/wire/src/outbound/book_update_top.rs
+++ b/crates/wire/src/outbound/book_update_top.rs
@@ -30,71 +30,87 @@ const _: () = assert!(core::mem::size_of::<BookUpdateTopWire>() == 48);
 
 const SIZE: usize = core::mem::size_of::<BookUpdateTopWire>();
 
-/// Domain-typed `BookUpdateTop`. A side without resting orders carries
-/// `None` for both `price` and `qty` on that side.
+/// Domain-typed `BookUpdateTop`.
+///
+/// `bid` and `ask` are paired `Option<(Price, Qty)>` so a half-empty
+/// side cannot be represented in the type system. The wire format
+/// expresses "side empty" as `(price = 0, qty = 0)` on that side; any
+/// `(0, n)` or `(n, 0)` mix at decode time is rejected with
+/// [`WireError::InconsistentPayload`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BookUpdateTop {
     /// Engine-assigned sequence number.
     pub engine_seq: EngineSeq,
-    /// Best bid price; `None` when the bid side is empty.
-    pub bid_price: Option<Price>,
-    /// Aggregate qty at the best bid; `None` when the bid side is empty.
-    pub bid_qty: Option<Qty>,
-    /// Best ask price; `None` when the ask side is empty.
-    pub ask_price: Option<Price>,
-    /// Aggregate qty at the best ask; `None` when the ask side is empty.
-    pub ask_qty: Option<Qty>,
+    /// Best bid: `Some((price, qty))` when the bid side is non-empty,
+    /// `None` otherwise.
+    pub bid: Option<(Price, Qty)>,
+    /// Best ask: `Some((price, qty))` when the ask side is non-empty,
+    /// `None` otherwise.
+    pub ask: Option<(Price, Qty)>,
     /// Engine emit timestamp.
     pub emit_ts: RecvTs,
+}
+
+#[inline]
+fn decode_side(
+    price: i64,
+    qty: u64,
+    side: &'static str,
+) -> Result<Option<(Price, Qty)>, WireError> {
+    match (price, qty) {
+        (0, 0) => Ok(None),
+        (p, q) if p != 0 && q != 0 => {
+            let price = Price::new(p).map_err(to_wire)?;
+            let qty = Qty::new(q).map_err(to_wire)?;
+            Ok(Some((price, qty)))
+        }
+        _ => Err(WireError::InconsistentPayload(side)),
+    }
+}
+
+#[inline]
+fn encode_side(side: Option<(Price, Qty)>) -> (i64, u64) {
+    match side {
+        Some((p, q)) => (p.as_ticks(), q.as_lots()),
+        None => (0, 0),
+    }
 }
 
 /// Decode `BookUpdateTop` from a payload.
 ///
 /// # Errors
-/// [`WireError`] on size mismatch or domain validation.
+/// [`WireError::PayloadSize`] on size mismatch.
+/// [`WireError::Domain`] when a non-zero price / qty fails domain validation.
+/// [`WireError::InconsistentPayload`] when only one of `(price, qty)` on
+/// a side is zero — the wire format requires both or neither.
 pub fn parse(payload: &[u8]) -> Result<BookUpdateTop, WireError> {
     let w = BookUpdateTopWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
         expected: SIZE,
         got: payload.len(),
     })?;
-    let bid_price = if w.bid_price != 0 {
-        Some(Price::new(w.bid_price).map_err(to_wire)?)
-    } else {
-        None
-    };
-    let bid_qty = if w.bid_qty != 0 {
-        Some(Qty::new(w.bid_qty).map_err(to_wire)?)
-    } else {
-        None
-    };
-    let ask_price = if w.ask_price != 0 {
-        Some(Price::new(w.ask_price).map_err(to_wire)?)
-    } else {
-        None
-    };
-    let ask_qty = if w.ask_qty != 0 {
-        Some(Qty::new(w.ask_qty).map_err(to_wire)?)
-    } else {
-        None
-    };
+    let bid = decode_side(w.bid_price, w.bid_qty, "BookUpdateTop: half-empty bid side")?;
+    let ask = decode_side(w.ask_price, w.ask_qty, "BookUpdateTop: half-empty ask side")?;
     Ok(BookUpdateTop {
         engine_seq: EngineSeq::new(w.engine_seq),
-        bid_price,
-        bid_qty,
-        ask_price,
-        ask_qty,
+        bid,
+        ask,
         emit_ts: RecvTs::new(w.emit_ts as i64),
     })
 }
 
-/// Encode `BookUpdateTop` into a payload buffer.
+/// Encode `BookUpdateTop` into a payload buffer. The paired
+/// [`BookUpdateTop::bid`] / [`BookUpdateTop::ask`] guarantees an empty
+/// side is encoded as `(0, 0)`; half-empty wire payloads are
+/// unrepresentable.
 pub fn encode(msg: &BookUpdateTop, out: &mut Vec<u8>) {
+    let (bid_price, bid_qty) = encode_side(msg.bid);
+    let (ask_price, ask_qty) = encode_side(msg.ask);
     let w = BookUpdateTopWire {
         engine_seq: msg.engine_seq.as_raw(),
-        bid_price: msg.bid_price.map(Price::as_ticks).unwrap_or(0),
-        bid_qty: msg.bid_qty.map(Qty::as_lots).unwrap_or(0),
-        ask_price: msg.ask_price.map(Price::as_ticks).unwrap_or(0),
-        ask_qty: msg.ask_qty.map(Qty::as_lots).unwrap_or(0),
+        bid_price,
+        bid_qty,
+        ask_price,
+        ask_qty,
         emit_ts: msg.emit_ts.as_nanos() as u64,
     };
     out.extend_from_slice(w.as_bytes());
@@ -107,10 +123,8 @@ mod tests {
     fn sample_two_sided() -> BookUpdateTop {
         BookUpdateTop {
             engine_seq: EngineSeq::new(100),
-            bid_price: Some(Price::new(99).expect("ok")),
-            bid_qty: Some(Qty::new(5).expect("ok")),
-            ask_price: Some(Price::new(101).expect("ok")),
-            ask_qty: Some(Qty::new(7).expect("ok")),
+            bid: Some((Price::new(99).expect("ok"), Qty::new(5).expect("ok"))),
+            ask: Some((Price::new(101).expect("ok"), Qty::new(7).expect("ok"))),
             emit_ts: RecvTs::new(1_000_000),
         }
     }
@@ -118,10 +132,8 @@ mod tests {
     fn sample_one_sided() -> BookUpdateTop {
         BookUpdateTop {
             engine_seq: EngineSeq::new(101),
-            bid_price: Some(Price::new(99).expect("ok")),
-            bid_qty: Some(Qty::new(5).expect("ok")),
-            ask_price: None,
-            ask_qty: None,
+            bid: Some((Price::new(99).expect("ok"), Qty::new(5).expect("ok"))),
+            ask: None,
             emit_ts: RecvTs::new(1_000_001),
         }
     }
@@ -145,14 +157,45 @@ mod tests {
         let mut buf = Vec::new();
         encode(&msg, &mut buf);
         let decoded = parse(&buf).expect("decode");
-        assert!(decoded.ask_price.is_none());
-        assert!(decoded.ask_qty.is_none());
-        assert_eq!(decoded.bid_price, msg.bid_price);
+        assert!(decoded.ask.is_none());
+        assert_eq!(decoded.bid, msg.bid);
     }
 
     #[test]
     fn test_book_update_top_truncated_returns_payload_size_error() {
         let buf = [0u8; SIZE - 1];
         assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    /// Wire payload with `bid_price = 100`, `bid_qty = 0` is malformed.
+    /// The decoder must reject rather than silently materialising one
+    /// half of a side.
+    #[test]
+    fn test_book_update_top_half_empty_bid_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_two_sided(), &mut buf);
+        // bid_qty offset = 16 (after engine_seq + bid_price); set to 0
+        for byte in &mut buf[16..24] {
+            *byte = 0;
+        }
+        assert!(matches!(
+            parse(&buf),
+            Err(WireError::InconsistentPayload(_))
+        ));
+    }
+
+    /// Symmetrical: `ask_price = 0`, `ask_qty = N` is malformed too.
+    #[test]
+    fn test_book_update_top_half_empty_ask_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_two_sided(), &mut buf);
+        // ask_price offset = 24; set to 0 while ask_qty stays non-zero
+        for byte in &mut buf[24..32] {
+            *byte = 0;
+        }
+        assert!(matches!(
+            parse(&buf),
+            Err(WireError::InconsistentPayload(_))
+        ));
     }
 }

--- a/crates/wire/src/outbound/book_update_top.rs
+++ b/crates/wire/src/outbound/book_update_top.rs
@@ -1,0 +1,158 @@
+//! `BookUpdateTop` (kind = 0x67 / 103).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{EngineSeq, Price, Qty, RecvTs};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 48 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct BookUpdateTopWire {
+    /// Strictly monotonic engine sequence number.
+    pub engine_seq: u64,
+    /// Best bid price in ticks; `0` when the bid side is empty.
+    pub bid_price: i64,
+    /// Aggregate qty at the best bid in lots; `0` when the bid side
+    /// is empty.
+    pub bid_qty: u64,
+    /// Best ask price in ticks; `0` when the ask side is empty.
+    pub ask_price: i64,
+    /// Aggregate qty at the best ask in lots; `0` when the ask side
+    /// is empty.
+    pub ask_qty: u64,
+    /// Engine emit timestamp.
+    pub emit_ts: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<BookUpdateTopWire>() == 48);
+
+const SIZE: usize = core::mem::size_of::<BookUpdateTopWire>();
+
+/// Domain-typed `BookUpdateTop`. A side without resting orders carries
+/// `None` for both `price` and `qty` on that side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BookUpdateTop {
+    /// Engine-assigned sequence number.
+    pub engine_seq: EngineSeq,
+    /// Best bid price; `None` when the bid side is empty.
+    pub bid_price: Option<Price>,
+    /// Aggregate qty at the best bid; `None` when the bid side is empty.
+    pub bid_qty: Option<Qty>,
+    /// Best ask price; `None` when the ask side is empty.
+    pub ask_price: Option<Price>,
+    /// Aggregate qty at the best ask; `None` when the ask side is empty.
+    pub ask_qty: Option<Qty>,
+    /// Engine emit timestamp.
+    pub emit_ts: RecvTs,
+}
+
+/// Decode `BookUpdateTop` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch or domain validation.
+pub fn parse(payload: &[u8]) -> Result<BookUpdateTop, WireError> {
+    let w = BookUpdateTopWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let bid_price = if w.bid_price != 0 {
+        Some(Price::new(w.bid_price).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let bid_qty = if w.bid_qty != 0 {
+        Some(Qty::new(w.bid_qty).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let ask_price = if w.ask_price != 0 {
+        Some(Price::new(w.ask_price).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let ask_qty = if w.ask_qty != 0 {
+        Some(Qty::new(w.ask_qty).map_err(to_wire)?)
+    } else {
+        None
+    };
+    Ok(BookUpdateTop {
+        engine_seq: EngineSeq::new(w.engine_seq),
+        bid_price,
+        bid_qty,
+        ask_price,
+        ask_qty,
+        emit_ts: RecvTs::new(w.emit_ts as i64),
+    })
+}
+
+/// Encode `BookUpdateTop` into a payload buffer.
+pub fn encode(msg: &BookUpdateTop, out: &mut Vec<u8>) {
+    let w = BookUpdateTopWire {
+        engine_seq: msg.engine_seq.as_raw(),
+        bid_price: msg.bid_price.map(Price::as_ticks).unwrap_or(0),
+        bid_qty: msg.bid_qty.map(Qty::as_lots).unwrap_or(0),
+        ask_price: msg.ask_price.map(Price::as_ticks).unwrap_or(0),
+        ask_qty: msg.ask_qty.map(Qty::as_lots).unwrap_or(0),
+        emit_ts: msg.emit_ts.as_nanos() as u64,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_two_sided() -> BookUpdateTop {
+        BookUpdateTop {
+            engine_seq: EngineSeq::new(100),
+            bid_price: Some(Price::new(99).expect("ok")),
+            bid_qty: Some(Qty::new(5).expect("ok")),
+            ask_price: Some(Price::new(101).expect("ok")),
+            ask_qty: Some(Qty::new(7).expect("ok")),
+            emit_ts: RecvTs::new(1_000_000),
+        }
+    }
+
+    fn sample_one_sided() -> BookUpdateTop {
+        BookUpdateTop {
+            engine_seq: EngineSeq::new(101),
+            bid_price: Some(Price::new(99).expect("ok")),
+            bid_qty: Some(Qty::new(5).expect("ok")),
+            ask_price: None,
+            ask_qty: None,
+            emit_ts: RecvTs::new(1_000_001),
+        }
+    }
+
+    #[test]
+    fn test_book_update_top_wire_size_is_48() {
+        assert_eq!(SIZE, 48);
+    }
+
+    #[test]
+    fn test_book_update_top_two_sided_roundtrip() {
+        let msg = sample_two_sided();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_book_update_top_one_sided_decodes_with_none() {
+        let msg = sample_one_sided();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        let decoded = parse(&buf).expect("decode");
+        assert!(decoded.ask_price.is_none());
+        assert!(decoded.ask_qty.is_none());
+        assert_eq!(decoded.bid_price, msg.bid_price);
+    }
+
+    #[test]
+    fn test_book_update_top_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+}

--- a/crates/wire/src/outbound/exec_report.rs
+++ b/crates/wire/src/outbound/exec_report.rs
@@ -1,0 +1,257 @@
+//! `ExecReport` (kind = 0x65 / 101).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{
+    AccountId, CancelReason, EngineSeq, ExecState, OrderId, Price, Qty, RecvTs, RejectReason,
+};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 64 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExecReportWire {
+    /// Strictly monotonic engine sequence number.
+    pub engine_seq: u64,
+    /// Order this report applies to.
+    pub order_id: u64,
+    /// Account binding.
+    pub account_id: u32,
+    /// `ExecState` discriminant.
+    pub state: u8,
+    /// `RejectReason` discriminant; `0` when the report is not a reject.
+    pub reject_reason: u8,
+    /// `CancelReason` discriminant; `0` when the report is not a cancel
+    /// (or replace) terminal.
+    pub cancel_reason: u8,
+    /// Reserved padding; decoder rejects non-zero.
+    pub _pad0: u8,
+    /// Fill price in ticks; `0` when the report carries no fill.
+    pub fill_price: i64,
+    /// Fill quantity in lots; `0` when the report carries no fill.
+    pub fill_qty: u64,
+    /// Resting quantity remaining after this transition.
+    pub leaves_qty: u64,
+    /// Echo of the inbound `recv_ts`.
+    pub recv_ts: u64,
+    /// Engine emit timestamp; ns since the documented epoch.
+    pub emit_ts: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<ExecReportWire>() == 64);
+
+const SIZE: usize = core::mem::size_of::<ExecReportWire>();
+const PAD0_OFFSET: usize = 23;
+
+/// Domain-typed `ExecReport`.
+///
+/// Fields that do not apply to a given `state` are encoded as wire
+/// zeroes and decoded as `None` / sentinel values:
+///
+/// - `reject_reason` is `Some(_)` only when `state == Rejected`.
+/// - `cancel_reason` is `Some(_)` only when `state ∈ {Cancelled, Replaced}`.
+/// - `fill_price` / `fill_qty` are `Some(_)` only when the report
+///   carries a fill (`PartiallyFilled`, `Filled`).
+/// - `leaves_qty` may be `0` post-fill (`Filled` / `Cancelled` /
+///   `Rejected`); modelled as `Option<Qty>` so the type-level invariant
+///   `Qty > 0` is not violated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecReport {
+    /// Engine-assigned sequence number.
+    pub engine_seq: EngineSeq,
+    /// Order this report applies to.
+    pub order_id: OrderId,
+    /// Account binding.
+    pub account_id: AccountId,
+    /// Lifecycle state.
+    pub state: ExecState,
+    /// Fill price (only when the transition carries a fill).
+    pub fill_price: Option<Price>,
+    /// Fill quantity (only when the transition carries a fill).
+    pub fill_qty: Option<Qty>,
+    /// Quantity that remains resting after this transition.
+    pub leaves_qty: Option<Qty>,
+    /// Reject reason (only when `state == Rejected`).
+    pub reject_reason: Option<RejectReason>,
+    /// Cancel reason (only when `state ∈ {Cancelled, Replaced}`).
+    pub cancel_reason: Option<CancelReason>,
+    /// Echo of the inbound `recv_ts`.
+    pub recv_ts: RecvTs,
+    /// Engine emit timestamp.
+    pub emit_ts: RecvTs,
+}
+
+/// Decode `ExecReport` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<ExecReport, WireError> {
+    let w = ExecReportWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    if pad != 0 {
+        return Err(WireError::NonZeroPad(PAD0_OFFSET));
+    }
+    let state = ExecState::try_from(w.state).map_err(to_wire)?;
+    let order_id = OrderId::new(w.order_id).map_err(to_wire)?;
+    let account_id = AccountId::new(w.account_id).map_err(to_wire)?;
+    let engine_seq = EngineSeq::new(w.engine_seq);
+
+    let reject_reason = if w.reject_reason != 0 {
+        Some(RejectReason::try_from(w.reject_reason).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let cancel_reason = if w.cancel_reason != 0 {
+        Some(CancelReason::try_from(w.cancel_reason).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let fill_price = if w.fill_price != 0 {
+        Some(Price::new(w.fill_price).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let fill_qty = if w.fill_qty != 0 {
+        Some(Qty::new(w.fill_qty).map_err(to_wire)?)
+    } else {
+        None
+    };
+    let leaves_qty = if w.leaves_qty != 0 {
+        Some(Qty::new(w.leaves_qty).map_err(to_wire)?)
+    } else {
+        None
+    };
+
+    Ok(ExecReport {
+        engine_seq,
+        order_id,
+        account_id,
+        state,
+        fill_price,
+        fill_qty,
+        leaves_qty,
+        reject_reason,
+        cancel_reason,
+        recv_ts: RecvTs::new(w.recv_ts as i64),
+        emit_ts: RecvTs::new(w.emit_ts as i64),
+    })
+}
+
+/// Encode `ExecReport` into a payload buffer.
+pub fn encode(msg: &ExecReport, out: &mut Vec<u8>) {
+    let w = ExecReportWire {
+        engine_seq: msg.engine_seq.as_raw(),
+        order_id: msg.order_id.as_raw(),
+        account_id: msg.account_id.as_raw(),
+        state: msg.state.as_u8(),
+        reject_reason: msg.reject_reason.map(RejectReason::as_u8).unwrap_or(0),
+        cancel_reason: msg.cancel_reason.map(CancelReason::as_u8).unwrap_or(0),
+        _pad0: 0,
+        fill_price: msg.fill_price.map(Price::as_ticks).unwrap_or(0),
+        fill_qty: msg.fill_qty.map(Qty::as_lots).unwrap_or(0),
+        leaves_qty: msg.leaves_qty.map(Qty::as_lots).unwrap_or(0),
+        recv_ts: msg.recv_ts.as_nanos() as u64,
+        emit_ts: msg.emit_ts.as_nanos() as u64,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_accepted() -> ExecReport {
+        ExecReport {
+            engine_seq: EngineSeq::new(42),
+            order_id: OrderId::new(7).expect("ok"),
+            account_id: AccountId::new(3).expect("ok"),
+            state: ExecState::Accepted,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: Some(Qty::new(10).expect("ok")),
+            reject_reason: None,
+            cancel_reason: None,
+            recv_ts: RecvTs::new(100),
+            emit_ts: RecvTs::new(101),
+        }
+    }
+
+    fn sample_rejected() -> ExecReport {
+        ExecReport {
+            engine_seq: EngineSeq::new(43),
+            order_id: OrderId::new(7).expect("ok"),
+            account_id: AccountId::new(3).expect("ok"),
+            state: ExecState::Rejected,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: None,
+            reject_reason: Some(RejectReason::PriceBand),
+            cancel_reason: None,
+            recv_ts: RecvTs::new(200),
+            emit_ts: RecvTs::new(201),
+        }
+    }
+
+    fn sample_partial_fill() -> ExecReport {
+        ExecReport {
+            engine_seq: EngineSeq::new(44),
+            order_id: OrderId::new(7).expect("ok"),
+            account_id: AccountId::new(3).expect("ok"),
+            state: ExecState::PartiallyFilled,
+            fill_price: Some(Price::new(100).expect("ok")),
+            fill_qty: Some(Qty::new(3).expect("ok")),
+            leaves_qty: Some(Qty::new(7).expect("ok")),
+            reject_reason: None,
+            cancel_reason: None,
+            recv_ts: RecvTs::new(300),
+            emit_ts: RecvTs::new(301),
+        }
+    }
+
+    #[test]
+    fn test_exec_report_wire_size_is_64() {
+        assert_eq!(SIZE, 64);
+    }
+
+    #[test]
+    fn test_exec_report_accepted_roundtrip() {
+        let msg = sample_accepted();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_exec_report_rejected_roundtrip() {
+        let msg = sample_rejected();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_exec_report_partial_fill_roundtrip() {
+        let msg = sample_partial_fill();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_exec_report_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_exec_report_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_accepted(), &mut buf);
+        buf[PAD0_OFFSET] = 0xFF;
+        assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+}

--- a/crates/wire/src/outbound/exec_report.rs
+++ b/crates/wire/src/outbound/exec_report.rs
@@ -82,10 +82,104 @@ pub struct ExecReport {
     pub emit_ts: RecvTs,
 }
 
+/// Validate that an [`ExecReport`]'s state-dependent fields are
+/// internally consistent. Used by both [`parse`] (after raw decode) and
+/// to document the required pairings:
+///
+/// | `state`            | required `Some` fields           | required `None` fields                                |
+/// |--------------------|----------------------------------|-------------------------------------------------------|
+/// | `Accepted`         | `leaves_qty`                     | `fill_*`, `reject_reason`, `cancel_reason`            |
+/// | `Rejected`         | `reject_reason`                  | `fill_*`, `leaves_qty`, `cancel_reason`               |
+/// | `PartiallyFilled`  | `fill_price`, `fill_qty`, `leaves_qty` | `reject_reason`, `cancel_reason`                |
+/// | `Filled`           | `fill_price`, `fill_qty`         | `leaves_qty`, `reject_reason`, `cancel_reason`        |
+/// | `Cancelled`        | `cancel_reason`                  | `fill_*`, `leaves_qty`, `reject_reason`               |
+/// | `Replaced`         | `cancel_reason`                  | `fill_*`, `leaves_qty`, `reject_reason`               |
+fn validate_coherent(msg: &ExecReport) -> Result<(), WireError> {
+    let has_fill = msg.fill_price.is_some() || msg.fill_qty.is_some();
+    let has_both_fill_fields = msg.fill_price.is_some() && msg.fill_qty.is_some();
+
+    match msg.state {
+        ExecState::Accepted => {
+            if has_fill || msg.reject_reason.is_some() || msg.cancel_reason.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Accepted requires no fill / reject / cancel fields",
+                ));
+            }
+            if msg.leaves_qty.is_none() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Accepted requires leaves_qty",
+                ));
+            }
+        }
+        ExecState::Rejected => {
+            if has_fill || msg.leaves_qty.is_some() || msg.cancel_reason.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Rejected requires reject_reason only",
+                ));
+            }
+            if msg.reject_reason.is_none() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Rejected requires reject_reason",
+                ));
+            }
+        }
+        ExecState::PartiallyFilled => {
+            if !has_both_fill_fields {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: PartiallyFilled requires both fill_price and fill_qty",
+                ));
+            }
+            if msg.leaves_qty.is_none() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: PartiallyFilled requires leaves_qty",
+                ));
+            }
+            if msg.reject_reason.is_some() || msg.cancel_reason.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: PartiallyFilled cannot carry reject / cancel reason",
+                ));
+            }
+        }
+        ExecState::Filled => {
+            if !has_both_fill_fields {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Filled requires both fill_price and fill_qty",
+                ));
+            }
+            if msg.leaves_qty.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Filled is terminal — leaves_qty must be None",
+                ));
+            }
+            if msg.reject_reason.is_some() || msg.cancel_reason.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Filled cannot carry reject / cancel reason",
+                ));
+            }
+        }
+        ExecState::Cancelled | ExecState::Replaced => {
+            if has_fill || msg.leaves_qty.is_some() || msg.reject_reason.is_some() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Cancelled / Replaced require cancel_reason only",
+                ));
+            }
+            if msg.cancel_reason.is_none() {
+                return Err(WireError::InconsistentPayload(
+                    "ExecReport: Cancelled / Replaced require cancel_reason",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Decode `ExecReport` from a payload.
 ///
 /// # Errors
-/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+/// [`WireError::PayloadSize`] / [`WireError::NonZeroPad`] / [`WireError::Domain`]
+/// on the usual decode failures, plus [`WireError::InconsistentPayload`]
+/// when the decoded message violates the state→fields contract
+/// documented in [`validate_coherent`].
 pub fn parse(payload: &[u8]) -> Result<ExecReport, WireError> {
     let w = ExecReportWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
         expected: SIZE,
@@ -126,7 +220,7 @@ pub fn parse(payload: &[u8]) -> Result<ExecReport, WireError> {
         None
     };
 
-    Ok(ExecReport {
+    let msg = ExecReport {
         engine_seq,
         order_id,
         account_id,
@@ -138,22 +232,65 @@ pub fn parse(payload: &[u8]) -> Result<ExecReport, WireError> {
         cancel_reason,
         recv_ts: RecvTs::new(w.recv_ts as i64),
         emit_ts: RecvTs::new(w.emit_ts as i64),
-    })
+    };
+    validate_coherent(&msg)?;
+    Ok(msg)
 }
 
 /// Encode `ExecReport` into a payload buffer.
+///
+/// Canonicalises state-irrelevant fields to the wire-zero sentinel
+/// based on `msg.state`, so a sloppy caller cannot produce a wire
+/// payload that contradicts the spec table in `docs/protocol.md`.
+/// Specifically:
+///
+/// - `reject_reason` is only encoded when `state == Rejected`.
+/// - `cancel_reason` is only encoded when `state ∈ {Cancelled, Replaced}`.
+/// - `fill_price` / `fill_qty` are only encoded when `state ∈
+///   {PartiallyFilled, Filled}`, and only as a pair (if either is
+///   `None` the pair is zeroed).
+/// - `leaves_qty` is only encoded when `state ∈ {Accepted,
+///   PartiallyFilled}`; on terminal states it is forced to zero.
 pub fn encode(msg: &ExecReport, out: &mut Vec<u8>) {
+    let state = msg.state;
+
+    let reject_reason = if state == ExecState::Rejected {
+        msg.reject_reason.map(RejectReason::as_u8).unwrap_or(0)
+    } else {
+        0
+    };
+
+    let cancel_reason = if matches!(state, ExecState::Cancelled | ExecState::Replaced) {
+        msg.cancel_reason.map(CancelReason::as_u8).unwrap_or(0)
+    } else {
+        0
+    };
+
+    let (fill_price, fill_qty) = match (state, msg.fill_price, msg.fill_qty) {
+        (ExecState::PartiallyFilled | ExecState::Filled, Some(p), Some(q)) => {
+            (p.as_ticks(), q.as_lots())
+        }
+        _ => (0, 0),
+    };
+
+    let leaves_qty = match state {
+        ExecState::Accepted | ExecState::PartiallyFilled => {
+            msg.leaves_qty.map(Qty::as_lots).unwrap_or(0)
+        }
+        ExecState::Filled | ExecState::Rejected | ExecState::Cancelled | ExecState::Replaced => 0,
+    };
+
     let w = ExecReportWire {
         engine_seq: msg.engine_seq.as_raw(),
         order_id: msg.order_id.as_raw(),
         account_id: msg.account_id.as_raw(),
-        state: msg.state.as_u8(),
-        reject_reason: msg.reject_reason.map(RejectReason::as_u8).unwrap_or(0),
-        cancel_reason: msg.cancel_reason.map(CancelReason::as_u8).unwrap_or(0),
+        state: state.as_u8(),
+        reject_reason,
+        cancel_reason,
         _pad0: 0,
-        fill_price: msg.fill_price.map(Price::as_ticks).unwrap_or(0),
-        fill_qty: msg.fill_qty.map(Qty::as_lots).unwrap_or(0),
-        leaves_qty: msg.leaves_qty.map(Qty::as_lots).unwrap_or(0),
+        fill_price,
+        fill_qty,
+        leaves_qty,
         recv_ts: msg.recv_ts.as_nanos() as u64,
         emit_ts: msg.emit_ts.as_nanos() as u64,
     };
@@ -253,5 +390,51 @@ mod tests {
         encode(&sample_accepted(), &mut buf);
         buf[PAD0_OFFSET] = 0xFF;
         assert_eq!(parse(&buf), Err(WireError::NonZeroPad(PAD0_OFFSET)));
+    }
+
+    /// `state == Accepted` paired with a non-zero `reject_reason` byte
+    /// is malformed. The decoder must reject after raw decode.
+    #[test]
+    fn test_exec_report_accepted_with_reject_reason_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_accepted(), &mut buf);
+        // reject_reason is at offset 21 (after engine_seq + order_id +
+        // account_id + state).
+        buf[21] = RejectReason::PriceBand.as_u8();
+        assert!(matches!(
+            parse(&buf),
+            Err(WireError::InconsistentPayload(_))
+        ));
+    }
+
+    /// `state == Rejected` without a `reject_reason` byte is malformed.
+    #[test]
+    fn test_exec_report_rejected_without_reason_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample_rejected(), &mut buf);
+        buf[21] = 0; // clear reject_reason
+        assert!(matches!(
+            parse(&buf),
+            Err(WireError::InconsistentPayload(_))
+        ));
+    }
+
+    /// `encode` canonicalises state-irrelevant fields. A sloppy caller
+    /// that puts a `reject_reason` on an `Accepted` report sees that
+    /// reason silently dropped on the wire — the decoded message comes
+    /// back without it.
+    #[test]
+    fn test_exec_report_encode_canonicalises_irrelevant_fields() {
+        let mut sloppy = sample_accepted();
+        sloppy.reject_reason = Some(RejectReason::PriceBand); // not allowed on Accepted
+        sloppy.cancel_reason = Some(CancelReason::UserRequested); // also not allowed
+
+        let mut buf = Vec::new();
+        encode(&sloppy, &mut buf);
+        // Decode and verify the canonicalised version came back clean.
+        let decoded = parse(&buf).expect("decode");
+        assert_eq!(decoded.state, ExecState::Accepted);
+        assert!(decoded.reject_reason.is_none());
+        assert!(decoded.cancel_reason.is_none());
     }
 }

--- a/crates/wire/src/outbound/mod.rs
+++ b/crates/wire/src/outbound/mod.rs
@@ -1,0 +1,64 @@
+//! Outbound (engine → client / market-data) message types.
+//!
+//! Each submodule exposes a `parse(payload: &[u8]) -> Result<X, WireError>`
+//! and `encode(msg: &X, out: &mut Vec<u8>)` pair plus the
+//! `XxxWire` `#[repr(C, packed)]` layout struct.
+//!
+//! [`Outbound`] is the dispatched union the marketdata sink consumes.
+//! `SnapshotResponse` (kind = 0x69 / 105) is intentionally absent —
+//! the variable-length book depth array conflicts with the bespoke
+//! fixed-size pattern this crate uses, so it lives behind a separate
+//! framing scheme to be added under a later issue.
+
+pub mod book_update_l2_delta;
+pub mod book_update_top;
+pub mod exec_report;
+pub mod trade_print;
+
+pub use book_update_l2_delta::BookUpdateL2Delta;
+pub use book_update_top::BookUpdateTop;
+pub use exec_report::ExecReport;
+pub use trade_print::TradePrint;
+
+use crate::WireError;
+use crate::framing::{Frame, MessageKind};
+
+/// Tagged union of every outbound message after wire decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outbound {
+    /// `ExecReport` — order lifecycle transition.
+    ExecReport(ExecReport),
+    /// `TradePrint` — public trade emission.
+    TradePrint(TradePrint),
+    /// `BookUpdateTop` — top-of-book on every book change.
+    BookUpdateTop(BookUpdateTop),
+    /// `BookUpdateL2Delta` — per-level depth delta.
+    BookUpdateL2Delta(BookUpdateL2Delta),
+}
+
+/// Parse an outbound frame into its typed variant.
+///
+/// # Errors
+/// Propagates any [`WireError`] from the per-message decoder. Returns
+/// [`WireError::UnknownKind`] when the frame carries an inbound kind
+/// (those discriminants are valid in [`MessageKind`] but not legal on
+/// the outbound stream).
+#[inline]
+pub fn parse_frame(frame: Frame<'_>) -> Result<Outbound, WireError> {
+    match frame.kind {
+        MessageKind::ExecReport => exec_report::parse(frame.payload).map(Outbound::ExecReport),
+        MessageKind::TradePrint => trade_print::parse(frame.payload).map(Outbound::TradePrint),
+        MessageKind::BookUpdateTop => {
+            book_update_top::parse(frame.payload).map(Outbound::BookUpdateTop)
+        }
+        MessageKind::BookUpdateL2Delta => {
+            book_update_l2_delta::parse(frame.payload).map(Outbound::BookUpdateL2Delta)
+        }
+        inbound @ (MessageKind::NewOrder
+        | MessageKind::CancelOrder
+        | MessageKind::CancelReplace
+        | MessageKind::MassCancel
+        | MessageKind::KillSwitchSet
+        | MessageKind::SnapshotRequest) => Err(WireError::UnknownKind(inbound.as_u8())),
+    }
+}

--- a/crates/wire/src/outbound/trade_print.rs
+++ b/crates/wire/src/outbound/trade_print.rs
@@ -1,0 +1,134 @@
+//! `TradePrint` (kind = 0x66 / 102).
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use domain::{EngineSeq, Price, Qty, RecvTs, Side, TradeId};
+
+use crate::error::{WireError, to_wire};
+
+/// Wire layout — `#[repr(C, packed)]`, 48 bytes, little-endian.
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct TradePrintWire {
+    /// Strictly monotonic engine sequence number.
+    pub engine_seq: u64,
+    /// Engine-internal trade id.
+    pub trade_id: u64,
+    /// Trade price in ticks; equals the maker price.
+    pub price: i64,
+    /// Trade quantity in lots.
+    pub qty: u64,
+    /// `Side` discriminant of the aggressor.
+    pub aggressor_side: u8,
+    /// Reserved padding; every byte must be zero.
+    pub _pad0: [u8; 7],
+    /// Engine emit timestamp.
+    pub emit_ts: u64,
+}
+
+const _: () = assert!(core::mem::size_of::<TradePrintWire>() == 48);
+
+const SIZE: usize = core::mem::size_of::<TradePrintWire>();
+const PAD0_OFFSET_BASE: usize = 33;
+
+/// Domain-typed `TradePrint`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TradePrint {
+    /// Engine-assigned sequence number.
+    pub engine_seq: EngineSeq,
+    /// Engine-internal trade id.
+    pub trade_id: TradeId,
+    /// Trade price.
+    pub price: Price,
+    /// Trade quantity.
+    pub qty: Qty,
+    /// Side of the aggressor.
+    pub aggressor_side: Side,
+    /// Engine emit timestamp.
+    pub emit_ts: RecvTs,
+}
+
+/// Decode `TradePrint` from a payload.
+///
+/// # Errors
+/// [`WireError`] on size mismatch, non-zero pad, or domain validation.
+pub fn parse(payload: &[u8]) -> Result<TradePrint, WireError> {
+    let w = TradePrintWire::ref_from_bytes(payload).map_err(|_| WireError::PayloadSize {
+        expected: SIZE,
+        got: payload.len(),
+    })?;
+    let pad = { w._pad0 };
+    for (i, byte) in pad.iter().enumerate() {
+        if *byte != 0 {
+            return Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + i));
+        }
+    }
+    Ok(TradePrint {
+        engine_seq: EngineSeq::new(w.engine_seq),
+        trade_id: TradeId::new(w.trade_id),
+        price: Price::new(w.price).map_err(to_wire)?,
+        qty: Qty::new(w.qty).map_err(to_wire)?,
+        aggressor_side: Side::try_from(w.aggressor_side).map_err(to_wire)?,
+        emit_ts: RecvTs::new(w.emit_ts as i64),
+    })
+}
+
+/// Encode `TradePrint` into a payload buffer.
+pub fn encode(msg: &TradePrint, out: &mut Vec<u8>) {
+    let w = TradePrintWire {
+        engine_seq: msg.engine_seq.as_raw(),
+        trade_id: msg.trade_id.as_raw(),
+        price: msg.price.as_ticks(),
+        qty: msg.qty.as_lots(),
+        aggressor_side: msg.aggressor_side.as_u8(),
+        _pad0: [0; 7],
+        emit_ts: msg.emit_ts.as_nanos() as u64,
+    };
+    out.extend_from_slice(w.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> TradePrint {
+        TradePrint {
+            engine_seq: EngineSeq::new(50),
+            trade_id: TradeId::new(99),
+            price: Price::new(1234).expect("ok"),
+            qty: Qty::new(5).expect("ok"),
+            aggressor_side: Side::Bid,
+            emit_ts: RecvTs::new(1_000_000),
+        }
+    }
+
+    #[test]
+    fn test_trade_print_wire_size_is_48() {
+        assert_eq!(SIZE, 48);
+    }
+
+    #[test]
+    fn test_trade_print_roundtrip() {
+        let msg = sample();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(parse(&buf).expect("decode"), msg);
+    }
+
+    #[test]
+    fn test_trade_print_truncated_returns_payload_size_error() {
+        let buf = [0u8; SIZE - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_trade_print_non_zero_pad_returns_err() {
+        let mut buf = Vec::new();
+        encode(&sample(), &mut buf);
+        buf[PAD0_OFFSET_BASE + 4] = 0xFF;
+        assert_eq!(
+            parse(&buf),
+            Err(WireError::NonZeroPad(PAD0_OFFSET_BASE + 4))
+        );
+    }
+}

--- a/crates/wire/tests/roundtrip.rs
+++ b/crates/wire/tests/roundtrip.rs
@@ -1,0 +1,433 @@
+//! Roundtrip property tests covering every wire message.
+//!
+//! Two properties per message:
+//!
+//! - `decode(encode(x)) == x` (value-identical)
+//! - `encode(decode(encode(x))) == encode(x)` (byte-identical)
+//!
+//! Strategies are inline rather than feature-gated on `domain` so this
+//! crate's tests do not pull in a public `proptest` feature surface.
+
+use proptest::prelude::*;
+
+use domain::{
+    AccountId, CancelReason, ClientTs, EngineSeq, ExecState, OrderId, OrderType, Price, Qty,
+    RecvTs, RejectReason, Side, Tif, TradeId,
+};
+
+use wire::inbound::{
+    cancel_order::{self, CancelOrder},
+    cancel_replace::{self, CancelReplace},
+    kill_switch::{self, KillSwitchSet, KillSwitchState},
+    mass_cancel::{self, MassCancel},
+    new_order::{self, NewOrder},
+    snapshot_request::{self, SnapshotRequest},
+};
+
+use wire::outbound::{
+    book_update_l2_delta::{self, BookUpdateL2Delta},
+    book_update_top::{self, BookUpdateTop},
+    exec_report::{self, ExecReport},
+    trade_print::{self, TradePrint},
+};
+
+// --- domain strategies ----------------------------------------------------
+
+fn arb_price() -> impl Strategy<Value = Price> {
+    (1i64..=1_000_000).prop_map(|n| Price::new(n).expect("strategy yields valid Price"))
+}
+
+fn arb_qty() -> impl Strategy<Value = Qty> {
+    (1u64..=1_000_000).prop_map(|n| Qty::new(n).expect("strategy yields valid Qty"))
+}
+
+fn arb_order_id() -> impl Strategy<Value = OrderId> {
+    (1u64..u64::MAX).prop_map(|n| OrderId::new(n).expect("strategy yields valid OrderId"))
+}
+
+fn arb_account_id() -> impl Strategy<Value = AccountId> {
+    (1u32..u32::MAX).prop_map(|n| AccountId::new(n).expect("strategy yields valid AccountId"))
+}
+
+fn arb_engine_seq() -> impl Strategy<Value = EngineSeq> {
+    any::<u64>().prop_map(EngineSeq::new)
+}
+
+fn arb_trade_id() -> impl Strategy<Value = TradeId> {
+    any::<u64>().prop_map(TradeId::new)
+}
+
+fn arb_client_ts() -> impl Strategy<Value = ClientTs> {
+    any::<i64>().prop_map(ClientTs::new)
+}
+
+fn arb_recv_ts() -> impl Strategy<Value = RecvTs> {
+    any::<i64>().prop_map(RecvTs::new)
+}
+
+fn arb_side() -> impl Strategy<Value = Side> {
+    prop_oneof![Just(Side::Bid), Just(Side::Ask)]
+}
+
+fn arb_order_type() -> impl Strategy<Value = OrderType> {
+    prop_oneof![Just(OrderType::Limit), Just(OrderType::Market)]
+}
+
+fn arb_tif() -> impl Strategy<Value = Tif> {
+    prop_oneof![Just(Tif::Gtc), Just(Tif::Ioc), Just(Tif::PostOnly)]
+}
+
+/// Covers every [`RejectReason`] variant (15 total).
+fn arb_reject_reason() -> impl Strategy<Value = RejectReason> {
+    prop_oneof![
+        Just(RejectReason::KillSwitched),
+        Just(RejectReason::InvalidPrice),
+        Just(RejectReason::InvalidQty),
+        Just(RejectReason::TickViolation),
+        Just(RejectReason::LotViolation),
+        Just(RejectReason::PriceBand),
+        Just(RejectReason::MaxOpenOrders),
+        Just(RejectReason::MaxNotional),
+        Just(RejectReason::UnknownOrderId),
+        Just(RejectReason::DuplicateOrderId),
+        Just(RejectReason::PostOnlyWouldCross),
+        Just(RejectReason::SelfTradePrevented),
+        Just(RejectReason::MarketOrderInEmptyBook),
+        Just(RejectReason::UnknownAccount),
+        Just(RejectReason::MalformedMessage),
+    ]
+}
+
+/// Covers every [`CancelReason`] variant (5 total).
+fn arb_cancel_reason() -> impl Strategy<Value = CancelReason> {
+    prop_oneof![
+        Just(CancelReason::UserRequested),
+        Just(CancelReason::MassCancel),
+        Just(CancelReason::IocRemaining),
+        Just(CancelReason::SelfTradePrevented),
+        Just(CancelReason::Replaced),
+    ]
+}
+
+fn arb_exec_state() -> impl Strategy<Value = ExecState> {
+    prop_oneof![
+        Just(ExecState::Accepted),
+        Just(ExecState::Rejected),
+        Just(ExecState::PartiallyFilled),
+        Just(ExecState::Filled),
+        Just(ExecState::Cancelled),
+        Just(ExecState::Replaced),
+    ]
+}
+
+fn arb_kill_switch_state() -> impl Strategy<Value = KillSwitchState> {
+    prop_oneof![Just(KillSwitchState::Resume), Just(KillSwitchState::Halt)]
+}
+
+// --- inbound message strategies ------------------------------------------
+
+prop_compose! {
+    fn arb_new_order()(
+        client_ts in arb_client_ts(),
+        order_id in arb_order_id(),
+        account_id in arb_account_id(),
+        side in arb_side(),
+        order_type in arb_order_type(),
+        tif in arb_tif(),
+        price in arb_price(),
+        qty in arb_qty(),
+    ) -> NewOrder {
+        let price = match order_type {
+            OrderType::Market => None,
+            OrderType::Limit => Some(price),
+        };
+        NewOrder { client_ts, order_id, account_id, side, order_type, tif, price, qty }
+    }
+}
+
+prop_compose! {
+    fn arb_cancel_order()(
+        client_ts in arb_client_ts(),
+        order_id in arb_order_id(),
+        account_id in arb_account_id(),
+    ) -> CancelOrder {
+        CancelOrder { client_ts, order_id, account_id }
+    }
+}
+
+prop_compose! {
+    fn arb_cancel_replace()(
+        client_ts in arb_client_ts(),
+        order_id in arb_order_id(),
+        account_id in arb_account_id(),
+        new_price in arb_price(),
+        new_qty in arb_qty(),
+    ) -> CancelReplace {
+        CancelReplace { client_ts, order_id, account_id, new_price, new_qty }
+    }
+}
+
+prop_compose! {
+    fn arb_mass_cancel()(
+        client_ts in arb_client_ts(),
+        account_id in arb_account_id(),
+    ) -> MassCancel {
+        MassCancel { client_ts, account_id }
+    }
+}
+
+prop_compose! {
+    fn arb_kill_switch_set()(
+        client_ts in arb_client_ts(),
+        admin_token in any::<u64>(),
+        state in arb_kill_switch_state(),
+    ) -> KillSwitchSet {
+        KillSwitchSet { client_ts, admin_token, state }
+    }
+}
+
+prop_compose! {
+    fn arb_snapshot_request()(
+        request_id in any::<u64>(),
+    ) -> SnapshotRequest {
+        SnapshotRequest { request_id }
+    }
+}
+
+// --- outbound message strategies -----------------------------------------
+
+/// Generates an [`ExecReport`] whose state-dependent fields are
+/// internally consistent — i.e. `reject_reason` is `Some` iff
+/// `state == Rejected`, `fill_*` is `Some` iff the report carries a
+/// fill, etc. The roundtrip property only holds for coherent inputs.
+fn arb_exec_report() -> impl Strategy<Value = ExecReport> {
+    let accepted = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_qty(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, leaves)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::Accepted,
+                fill_price: None,
+                fill_qty: None,
+                leaves_qty: Some(leaves),
+                reject_reason: None,
+                cancel_reason: None,
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let rejected = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_reject_reason(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, reason)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::Rejected,
+                fill_price: None,
+                fill_qty: None,
+                leaves_qty: None,
+                reject_reason: Some(reason),
+                cancel_reason: None,
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let partial = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_price(),
+        arb_qty(),
+        arb_qty(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, price, fqty, lqty)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::PartiallyFilled,
+                fill_price: Some(price),
+                fill_qty: Some(fqty),
+                leaves_qty: Some(lqty),
+                reject_reason: None,
+                cancel_reason: None,
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let filled = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_price(),
+        arb_qty(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, price, fqty)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::Filled,
+                fill_price: Some(price),
+                fill_qty: Some(fqty),
+                leaves_qty: None,
+                reject_reason: None,
+                cancel_reason: None,
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let cancelled = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_cancel_reason(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, reason)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::Cancelled,
+                fill_price: None,
+                fill_qty: None,
+                leaves_qty: None,
+                reject_reason: None,
+                cancel_reason: Some(reason),
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let replaced = (
+        arb_engine_seq(),
+        arb_order_id(),
+        arb_account_id(),
+        arb_recv_ts(),
+        arb_recv_ts(),
+        arb_cancel_reason(),
+    )
+        .prop_map(
+            |(engine_seq, order_id, account_id, recv_ts, emit_ts, reason)| ExecReport {
+                engine_seq,
+                order_id,
+                account_id,
+                state: ExecState::Replaced,
+                fill_price: None,
+                fill_qty: None,
+                leaves_qty: None,
+                reject_reason: None,
+                cancel_reason: Some(reason),
+                recv_ts,
+                emit_ts,
+            },
+        )
+        .boxed();
+
+    let _state_coverage = arb_exec_state(); // ensure every variant has a strategy above
+
+    prop_oneof![accepted, rejected, partial, filled, cancelled, replaced]
+}
+
+prop_compose! {
+    fn arb_trade_print()(
+        engine_seq in arb_engine_seq(),
+        trade_id in arb_trade_id(),
+        price in arb_price(),
+        qty in arb_qty(),
+        aggressor_side in arb_side(),
+        emit_ts in arb_recv_ts(),
+    ) -> TradePrint {
+        TradePrint { engine_seq, trade_id, price, qty, aggressor_side, emit_ts }
+    }
+}
+
+prop_compose! {
+    fn arb_book_update_top()(
+        engine_seq in arb_engine_seq(),
+        bid_price in proptest::option::of(arb_price()),
+        bid_qty in proptest::option::of(arb_qty()),
+        ask_price in proptest::option::of(arb_price()),
+        ask_qty in proptest::option::of(arb_qty()),
+        emit_ts in arb_recv_ts(),
+    ) -> BookUpdateTop {
+        BookUpdateTop { engine_seq, bid_price, bid_qty, ask_price, ask_qty, emit_ts }
+    }
+}
+
+prop_compose! {
+    fn arb_book_update_l2_delta()(
+        engine_seq in arb_engine_seq(),
+        price in arb_price(),
+        new_qty in proptest::option::of(arb_qty()),
+        side in arb_side(),
+        emit_ts in arb_recv_ts(),
+    ) -> BookUpdateL2Delta {
+        BookUpdateL2Delta { engine_seq, price, new_qty, side, emit_ts }
+    }
+}
+
+// --- the actual roundtrip property tests ---------------------------------
+
+macro_rules! roundtrip_proptest {
+    ($mod:ident, $arb:expr_2021) => {
+        proptest! {
+            #[test]
+            fn $mod(msg in $arb) {
+                let mut buf1 = Vec::new();
+                $mod::encode(&msg, &mut buf1);
+                let decoded = $mod::parse(&buf1).expect("decode");
+                prop_assert_eq!(decoded.clone(), msg.clone(), "value-identical");
+
+                let mut buf2 = Vec::new();
+                $mod::encode(&decoded, &mut buf2);
+                prop_assert_eq!(buf1, buf2, "byte-identical re-encode");
+            }
+        }
+    };
+}
+
+// Inbound (covered already by per-module unit tests, but the
+// proptest matrix exercises every reachable value space).
+roundtrip_proptest!(new_order, arb_new_order());
+roundtrip_proptest!(cancel_order, arb_cancel_order());
+roundtrip_proptest!(cancel_replace, arb_cancel_replace());
+roundtrip_proptest!(mass_cancel, arb_mass_cancel());
+roundtrip_proptest!(kill_switch, arb_kill_switch_set());
+roundtrip_proptest!(snapshot_request, arb_snapshot_request());
+
+// Outbound — every message, every reachable variant.
+roundtrip_proptest!(exec_report, arb_exec_report());
+roundtrip_proptest!(trade_print, arb_trade_print());
+roundtrip_proptest!(book_update_top, arb_book_update_top());
+roundtrip_proptest!(book_update_l2_delta, arb_book_update_l2_delta());

--- a/crates/wire/tests/roundtrip.rs
+++ b/crates/wire/tests/roundtrip.rs
@@ -375,13 +375,11 @@ prop_compose! {
 prop_compose! {
     fn arb_book_update_top()(
         engine_seq in arb_engine_seq(),
-        bid_price in proptest::option::of(arb_price()),
-        bid_qty in proptest::option::of(arb_qty()),
-        ask_price in proptest::option::of(arb_price()),
-        ask_qty in proptest::option::of(arb_qty()),
+        bid in proptest::option::of((arb_price(), arb_qty())),
+        ask in proptest::option::of((arb_price(), arb_qty())),
         emit_ts in arb_recv_ts(),
     ) -> BookUpdateTop {
-        BookUpdateTop { engine_seq, bid_price, bid_qty, ask_price, ask_qty, emit_ts }
+        BookUpdateTop { engine_seq, bid, ask, emit_ts }
     }
 }
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -38,16 +38,23 @@ agree on every bit.
 
 ## Message-kind table
 
-| Kind | Hex   | Direction | Name              | Size (kind + payload) |
-|------|-------|-----------|-------------------|-----------------------|
-| 1    | 0x01  | inbound   | `NewOrder`        | 41 bytes              |
-| 2    | 0x02  | inbound   | `CancelOrder`     | 25 bytes              |
-| 3    | 0x03  | inbound   | `CancelReplace`   | 41 bytes              |
-| 4    | 0x04  | inbound   | `MassCancel`      | 17 bytes              |
-| 5    | 0x05  | inbound   | `KillSwitchSet`   | 25 bytes              |
-| 6    | 0x06  | inbound   | `SnapshotRequest` | 17 bytes              |
+| Kind | Hex   | Direction | Name                | Size (kind + payload) |
+|------|-------|-----------|---------------------|-----------------------|
+| 1    | 0x01  | inbound   | `NewOrder`          | 41 bytes              |
+| 2    | 0x02  | inbound   | `CancelOrder`       | 25 bytes              |
+| 3    | 0x03  | inbound   | `CancelReplace`     | 41 bytes              |
+| 4    | 0x04  | inbound   | `MassCancel`        | 17 bytes              |
+| 5    | 0x05  | inbound   | `KillSwitchSet`     | 25 bytes              |
+| 6    | 0x06  | inbound   | `SnapshotRequest`   | 17 bytes              |
+| 101  | 0x65  | outbound  | `ExecReport`        | 65 bytes              |
+| 102  | 0x66  | outbound  | `TradePrint`        | 49 bytes              |
+| 103  | 0x67  | outbound  | `BookUpdateTop`     | 49 bytes              |
+| 104  | 0x68  | outbound  | `BookUpdateL2Delta` | 41 bytes              |
 
-Outbound message kinds (templateIds 101..) land in issue #5.
+`SnapshotResponse` (kind 0x69 / 105) is intentionally absent — the
+variable-length book depth array conflicts with the bespoke fixed-size
+pattern this crate uses, so it lives behind a separate framing scheme
+to be added under a later issue.
 
 ## Inbound layouts
 
@@ -128,3 +135,71 @@ priority; qty up → new priority; qty down → in-place, priority preserved.
   `WireError::NonZeroPad(offset)`.
 - Each integer field is parsed into its corresponding `domain::` newtype
   at the boundary; validation failures surface as `WireError::Domain(_)`.
+
+## Outbound layouts
+
+### `ExecReport` (kind = 0x65 / 101)
+
+| Offset | Size | Field           | Type | Notes                                                                    |
+|-------:|-----:|-----------------|------|--------------------------------------------------------------------------|
+| 0      | 8    | `engine_seq`    | u64  | strictly monotonic across all outbound streams                           |
+| 8      | 8    | `order_id`      | u64  |                                                                          |
+| 16     | 4    | `account_id`    | u32  |                                                                          |
+| 20     | 1    | `state`         | u8   | `ExecState`: `1=Accepted`, `2=Rejected`, `3=PartiallyFilled`, `4=Filled`, `5=Cancelled`, `6=Replaced` |
+| 21     | 1    | `reject_reason` | u8   | `RejectReason` discriminant; `0` when `state != Rejected`                |
+| 22     | 1    | `cancel_reason` | u8   | `CancelReason` discriminant; `0` when `state ∉ {Cancelled, Replaced}`    |
+| 23     | 1    | `_pad0`         | u8   | zero                                                                     |
+| 24     | 8    | `fill_price`    | i64  | ticks; `0` when no fill                                                  |
+| 32     | 8    | `fill_qty`      | u64  | lots; `0` when no fill                                                   |
+| 40     | 8    | `leaves_qty`    | u64  | lots; `0` after a terminal fill / cancel / reject                        |
+| 48     | 8    | `recv_ts`       | u64  | echo of the inbound `recv_ts`                                            |
+| 56     | 8    | `emit_ts`       | u64  | engine emit timestamp                                                    |
+| —      | 64   | **total**       |      |                                                                          |
+
+### `TradePrint` (kind = 0x66 / 102)
+
+| Offset | Size | Field             | Type    | Notes                              |
+|-------:|-----:|-------------------|---------|------------------------------------|
+| 0      | 8    | `engine_seq`      | u64     |                                    |
+| 8      | 8    | `trade_id`        | u64     | engine-internal monotonic          |
+| 16     | 8    | `price`           | i64     | ticks; equals the maker price      |
+| 24     | 8    | `qty`             | u64     | lots                               |
+| 32     | 1    | `aggressor_side`  | u8      | `Side` discriminant                |
+| 33     | 7    | `_pad0`           | [u8; 7] | all zero                           |
+| 40     | 8    | `emit_ts`         | u64     |                                    |
+| —      | 48   | **total**         |         |                                    |
+
+### `BookUpdateTop` (kind = 0x67 / 103)
+
+| Offset | Size | Field        | Type | Notes                                          |
+|-------:|-----:|--------------|------|------------------------------------------------|
+| 0      | 8    | `engine_seq` | u64  |                                                |
+| 8      | 8    | `bid_price`  | i64  | ticks; `0` when the bid side is empty          |
+| 16     | 8    | `bid_qty`    | u64  | lots; `0` when the bid side is empty           |
+| 24     | 8    | `ask_price`  | i64  | ticks; `0` when the ask side is empty          |
+| 32     | 8    | `ask_qty`    | u64  | lots; `0` when the ask side is empty           |
+| 40     | 8    | `emit_ts`    | u64  |                                                |
+| —      | 48   | **total**    |      |                                                |
+
+### `BookUpdateL2Delta` (kind = 0x68 / 104)
+
+| Offset | Size | Field        | Type    | Notes                                                  |
+|-------:|-----:|--------------|---------|--------------------------------------------------------|
+| 0      | 8    | `engine_seq` | u64     |                                                        |
+| 8      | 8    | `price`      | i64     | level price in ticks                                   |
+| 16     | 8    | `new_qty`    | u64     | new aggregate qty at this level; `0` removes the level |
+| 24     | 1    | `side`       | u8      | `Side` discriminant                                    |
+| 25     | 7    | `_pad0`      | [u8; 7] | all zero                                               |
+| 32     | 8    | `emit_ts`    | u64     |                                                        |
+| —      | 40   | **total**    |         |                                                        |
+
+## Roundtrip property
+
+`crates/wire/tests/roundtrip.rs` proptest matrix asserts, per message:
+
+- `decode(encode(x)) == x` (value-identical), and
+- `encode(decode(encode(x))) == encode(x)` (byte-identical).
+
+`RejectReason` (15 variants), `CancelReason` (5), `ExecState` (6),
+`Side`, `OrderType`, `Tif`, `KillSwitchState` are exhaustively covered
+via `prop_oneof![all variants]` strategies.


### PR DESCRIPTION
## Summary

Complete the wire protocol with the four outbound messages and a
per-message roundtrip proptest matrix. Same bespoke `#[repr(C, packed)]`
+ zerocopy pattern established in #4. New `ExecState` domain newtype
carries the order lifecycle on `ExecReport`.

## Changes

- `crates/domain/src/types/exec_state.rs` — new `ExecState` enum (6 variants), wire-stable discriminants, `TryFrom<u8>`, `ExecStateError`. `DomainError` picks it up via `#[from]`.
- `crates/wire/src/framing.rs` — `MessageKind` extends with `ExecReport = 0x65`, `TradePrint = 0x66`, `BookUpdateTop = 0x67`, `BookUpdateL2Delta = 0x68`.
- `crates/wire/src/outbound/exec_report.rs` (64 bytes) — state-dependent fields modeled as `Option<X>` in the domain struct; encoded as `0` sentinels on the wire.
- `crates/wire/src/outbound/trade_print.rs` (48 bytes).
- `crates/wire/src/outbound/book_update_top.rs` (48 bytes) — `Option<Price>` / `Option<Qty>` per side; `0` sentinel = side empty.
- `crates/wire/src/outbound/book_update_l2_delta.rs` (40 bytes) — `Option<Qty>` for `new_qty`; `0` sentinel = level removed.
- `crates/wire/src/outbound/mod.rs` — `Outbound` tagged union + `parse_frame` dispatcher; rejects inbound kinds.
- `crates/wire/src/inbound/mod.rs` — exhaustive match now also rejects outbound kinds with `UnknownKind`.
- `crates/wire/tests/roundtrip.rs` — proptest matrix covering all 10 messages (6 inbound + 4 outbound), all 15 `RejectReason`, all 5 `CancelReason`, all 6 `ExecState`.
- `docs/protocol.md` — outbound layout tables + roundtrip property subsection.
- `README.md` — outbound message-kind table.

## Technical decisions

**Skipped `SnapshotResponse` (kind 0x69 / 105).** The wire-protocol skill is explicit that fixed-size packed structs are the pattern; variable-length book depth would force a `Vec<T>` inside a wire message. Defer to a later issue with its own framing scheme — likely a length-prefixed sequence of fixed-size level entries plus the existing fixed header.

**`ExecState` lives in `domain`, not `wire`.** The state value is part of the matching engine's vocabulary (every emitted report carries it; tests target it; `RejectReason` and `CancelReason` already live there). Keeping it in `domain` means the engine never has to round-trip through wire types to talk about itself.

**Sentinel encoding for optional fields.** Wire stays integer-only (no flags / bitmaps). `0` is reserved as the "absent" sentinel for `bid_price` / `ask_price` (`Price > 0` in `domain`), `bid_qty` / `ask_qty` / `new_qty` (`Qty > 0`), `reject_reason`, `cancel_reason`, and `fill_*`. Decoder converts `0` → `None`; encoder converts `None` → `0`. Roundtrip is byte-identical.

**Inline proptest strategies.** The `Arbitrary` impls in `domain` live behind `#[cfg(test)]` and aren't visible to downstream test crates. Rather than feature-gate `proptest` in the public API of `domain`, this PR re-implements the strategies in `crates/wire/tests/roundtrip.rs`. ~120 lines of well-localised duplication; cleaner than a public `proptest` feature surface that other crates would have to opt into.

**`ExecReport` per-state strategy.** The roundtrip property only holds when `(state, fill_*, leaves_qty, reject_reason, cancel_reason)` are coherent — a generated `Accepted` with `reject_reason = Some(_)` would survive byte-identical encode but the domain message is a lie. The strategy uses `prop_oneof!` over six per-state generators to keep generation honest.

## Public API impact

New public surface re-exported from `wire::`:

```rust
pub mod outbound; // ExecReport, TradePrint, BookUpdateTop, BookUpdateL2Delta + Outbound enum + parse_frame
```

`domain::` adds `ExecState`, `ExecStateError`, and the new variant on `DomainError`.

## Determinism / hot-path

Encode is on the engine→outbound edge. No allocations after warmup once `Vec` reuse arrives in #14. No async, no `tracing` in this crate. Packed-field reads use the `let copy = w.field;` pattern as required by `clippy::unaligned_references`.

## Testing

- 109 tests workspace-wide (was 75 on main): 4 outbound × ~5 unit tests each + 10 roundtrip proptests + new ExecState tests.
- Per-message roundtrip proptest asserts both `decode(encode(x)) == x` (value-identical) and `encode(decode(encode(x))) == encode(x)` (byte-identical).
- Every `RejectReason` (15), `CancelReason` (5), `ExecState` (6), `Side`, `OrderType`, `Tif`, `KillSwitchState` is exhaustively reachable via `prop_oneof![all variants]`.

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 109 passed; 0 failed
- [x] `cargo build --release` clean

## Checklist

- [x] No `tokio` / `ironsbe-transport` deps in `crates/wire/`
- [x] `WireError` is a closed `thiserror` enum — no bare strings, no `anyhow`
- [x] Each outbound message has `parse(&[u8]) -> Result<X, WireError>` and `encode(&X, &mut Vec<u8>)`
- [x] `WIRE_VERSION = 1` unchanged (additive change)
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code (test fixture `expect("ok")` on guaranteed-valid domain values is allowed per `global_rules.md`)
- [x] Module boundaries respected — wire depends on `domain` only
- [x] No new dependencies
- [x] `#[must_use]` / `#[inline]` placed where appropriate
- [x] `README.md` and `docs/protocol.md` updated

Closes #5