### PR TITLE
feat(engine): single-writer pipeline + engine_seq (#12)

### DIFF
--- a/crates/engine/src/clock.rs
+++ b/crates/engine/src/clock.rs
@@ -1,0 +1,87 @@
+//! Wall-clock and stub `Clock` implementations.
+//!
+//! `crates/matching/` and `crates/risk/` both ban any direct
+//! `SystemTime` / `Instant::now` read (CLAUDE.md core invariants).
+//! The engine pipeline is the single layer allowed to read the wall
+//! clock; it stamps `recv_ts` on every inbound command and `emit_ts`
+//! on every outbound message via this trait.
+//!
+//! [`WallClock`] is the production source — `SystemTime::now()`
+//! relative to the UNIX epoch. [`StubClock`] yields a script of
+//! recorded values for byte-identical replay.
+
+use std::cell::Cell;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use domain::{Clock, RecvTs};
+
+/// Production wall-clock source.
+///
+/// Reads `SystemTime::now()` and converts to nanoseconds since the
+/// UNIX epoch. The conversion is exact for any timestamp in the
+/// representable range of `i64` nanoseconds (~1970 → ~2262).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WallClock;
+
+impl Clock for WallClock {
+    #[inline]
+    fn now(&self) -> RecvTs {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        RecvTs::new(nanos)
+    }
+}
+
+/// Replay-time stub clock. Yields a fixed recorded value, advanced
+/// explicitly via [`StubClock::set`]. Replay drives this alongside
+/// the recorded inbound stream so each `recv_ts` reproduces the
+/// original engine's view byte-for-byte.
+#[derive(Debug)]
+pub struct StubClock {
+    current: Cell<i64>,
+}
+
+impl StubClock {
+    /// Construct a stub clock at `nanos` since the UNIX epoch.
+    #[must_use]
+    pub fn new(nanos: i64) -> Self {
+        Self {
+            current: Cell::new(nanos),
+        }
+    }
+
+    /// Override the current timestamp — replay calls this between
+    /// inbound commands to step the clock forward.
+    #[inline]
+    pub fn set(&self, nanos: i64) {
+        self.current.set(nanos);
+    }
+}
+
+impl Clock for StubClock {
+    #[inline]
+    fn now(&self) -> RecvTs {
+        RecvTs::new(self.current.get())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wall_clock_returns_positive_nanos() {
+        let c = WallClock;
+        assert!(c.now().as_nanos() > 0);
+    }
+
+    #[test]
+    fn test_stub_clock_returns_set_value() {
+        let c = StubClock::new(42);
+        assert_eq!(c.now().as_nanos(), 42);
+        c.set(123);
+        assert_eq!(c.now().as_nanos(), 123);
+    }
+}

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1,0 +1,980 @@
+//! Single-writer matching pipeline.
+//!
+//! Wires gateway-decoded inbound commands through risk, then matching,
+//! then the outbound sink. Single-writer per CLAUDE.md: every state
+//! mutation in the book / risk / order registry happens on this
+//! thread, behind `&mut self`. No `tokio`, no `.await`, no global
+//! mutable state.
+//!
+//! Pipeline per inbound command (mirrors `doc/DESIGN.md` § 8):
+//!
+//! 1. `recv_ts = clock.now()` — engine-stamped, used for the inbound
+//!    command's exec report.
+//! 2. `risk.check_*(&cmd, …)` — kill switch, message validation,
+//!    price band, per-account caps.
+//! 3. **Defense in depth** — kill switch is re-checked immediately
+//!    before the matching call. CLAUDE.md "kill switch must be
+//!    observed before the matching step".
+//! 4. `book.<op>(…)` — single-writer matching mutation.
+//! 5. Emit ordered: per-fill (`TradePrint`, two `ExecReport`s);
+//!    terminal cancels (`ExecReport`); resting acceptance
+//!    (`ExecReport`); finally `BookUpdateTop` snapshot of the
+//!    post-step best bid / best ask.
+//! 6. `engine_seq` is bumped via [`IdGenerator::next_engine_seq`] for
+//!    every emitted message, strictly monotonic across the entire
+//!    outbound stream.
+
+use std::collections::HashMap;
+
+use domain::{
+    AccountId, CancelReason, Clock, EngineSeq, ExecState, IdGenerator, OrderId, Price, Qty, RecvTs,
+    RejectReason, Side, Tif,
+};
+use matching::{
+    AggressiveOrder, Book, Fill, MassCancellation, ReplaceOutcome, RestingOrder, StpCancellation,
+};
+use risk::{RiskState, notional_of};
+use wire::inbound::{
+    CancelOrder, CancelReplace, Inbound, KillSwitchSet, KillSwitchState, MassCancel, NewOrder,
+};
+use wire::outbound::{BookUpdateTop, ExecReport, Outbound, TradePrint};
+
+use crate::sink::OutboundSink;
+
+/// Per-resting-order metadata the engine keeps so it can stamp exec
+/// reports for terminal events (full fills, cancels, STP, mass-cancel).
+/// Lookup-only — never iterated into outputs.
+#[derive(Debug, Clone, Copy)]
+struct OrderRegistryEntry {
+    account_id: AccountId,
+    side: Side,
+    /// Original limit price * qty notional, used to back out the
+    /// per-account `RiskState.notional` on terminal events.
+    notional: u128,
+}
+
+/// Single-writer engine. Holds the book, risk state, clock, id
+/// generator, scratch buffers, and the per-order registry.
+///
+/// Construction is parameterised over the `Clock` / `IdGenerator` /
+/// `OutboundSink` traits; production wires `WallClock` +
+/// `CounterIdGenerator` + a marketdata SPSC sink, replay swaps in
+/// `StubClock` + a fresh `CounterIdGenerator` + a `VecSink` for the
+/// byte-identical diff.
+pub struct Engine<C: Clock, I: IdGenerator, S: OutboundSink> {
+    book: Book,
+    risk: RiskState,
+    clock: C,
+    ids: I,
+    sink: S,
+    /// Order id → registry entry. Point-lookup only.
+    registry: HashMap<OrderId, OrderRegistryEntry>,
+    /// Scratch buffer for fills produced by `match_aggressive`.
+    /// Reused across `step` calls — `clear()`'d at the top of each
+    /// match, never reallocated on the steady state.
+    fills_buf: Vec<Fill>,
+    /// Scratch buffer for STP cancellations. Same reuse semantics as
+    /// `fills_buf`.
+    stp_buf: Vec<StpCancellation>,
+    /// Scratch buffer for mass-cancel emissions.
+    mass_buf: Vec<MassCancellation>,
+}
+
+impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
+    /// Construct a fresh engine. Pre-sizes scratch buffers so steady-
+    /// state matching does not allocate (CLAUDE.md "zero allocation
+    /// on the hot path after warmup").
+    pub fn new(clock: C, ids: I, sink: S) -> Self {
+        Self {
+            book: Book::new(),
+            risk: RiskState::new(),
+            clock,
+            ids,
+            sink,
+            registry: HashMap::new(),
+            fills_buf: Vec::with_capacity(128),
+            stp_buf: Vec::with_capacity(16),
+            mass_buf: Vec::with_capacity(64),
+        }
+    }
+
+    /// Read-only view of the book — used by tests / snapshot paths.
+    #[must_use]
+    pub fn book(&self) -> &Book {
+        &self.book
+    }
+
+    /// Read-only view of the risk state.
+    #[must_use]
+    pub fn risk(&self) -> &RiskState {
+        &self.risk
+    }
+
+    /// Drive one inbound command through the full pipeline.
+    pub fn step(&mut self, inbound: Inbound) {
+        let recv_ts = self.clock.now();
+        match inbound {
+            Inbound::NewOrder(msg) => self.handle_new_order(msg, recv_ts),
+            Inbound::CancelOrder(msg) => self.handle_cancel_order(msg, recv_ts),
+            Inbound::CancelReplace(msg) => self.handle_cancel_replace(msg, recv_ts),
+            Inbound::MassCancel(msg) => self.handle_mass_cancel(msg, recv_ts),
+            Inbound::KillSwitchSet(msg) => self.handle_kill_switch(msg),
+            // SnapshotRequest support is intentionally deferred —
+            // tracked separately under the marketdata snapshot work.
+            Inbound::SnapshotRequest(_) => {}
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // NewOrder
+    // -----------------------------------------------------------------
+
+    fn handle_new_order(&mut self, msg: NewOrder, recv_ts: RecvTs) {
+        // Best opposite drives both the price-band reference for
+        // market orders and the post-only would-cross gate inside
+        // `match_aggressive`.
+        let best_opposite = match msg.side {
+            Side::Bid => self.book.best_ask(),
+            Side::Ask => self.book.best_bid(),
+        };
+
+        // Stage 1: risk check (kill / market-in-empty-book / band /
+        // account caps).
+        if let Err(reason) = self.risk.check_new_order(&msg, best_opposite) {
+            self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+
+        // Stage 2: defense in depth — re-check the kill switch
+        // immediately before the matching call. The risk check above
+        // is single-threaded so this can only fire on a concurrency
+        // bug, but CLAUDE.md mandates the explicit re-check.
+        if self.risk.is_kill_switched() {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::KillSwitched,
+                recv_ts,
+            );
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+
+        // Stage 3: matching walk. Scratch buffers reused.
+        self.fills_buf.clear();
+        self.stp_buf.clear();
+        let aggressive = AggressiveOrder {
+            order_id: msg.order_id,
+            account_id: msg.account_id,
+            side: msg.side,
+            price: msg.price,
+            qty: msg.qty,
+            tif: msg.tif,
+        };
+        let result = self.book.match_aggressive(
+            aggressive,
+            &mut self.ids,
+            &mut self.fills_buf,
+            &mut self.stp_buf,
+        );
+
+        // Stage 4a: post-only would-cross — emit Rejected and stop.
+        if result.taker_post_only_rejected {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::PostOnlyWouldCross,
+                recv_ts,
+            );
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+
+        // Stage 4b: emit per-fill. For each fill we publish the trade
+        // print and the two corresponding exec reports (maker + taker
+        // partial / full). Order: trade print first, then exec
+        // reports — `engine_seq` strictly monotonic across all three.
+        let mut taker_remaining_lots = msg.qty.as_lots();
+        // Snapshot len before mutating; clippy would flag the implicit
+        // borrow if we reused `&self.fills_buf` in the loop body.
+        let fills_count = self.fills_buf.len();
+        for i in 0..fills_count {
+            let fill = self.fills_buf[i];
+            taker_remaining_lots = taker_remaining_lots.saturating_sub(fill.qty.as_lots());
+            self.emit_trade_print_for_fill(&fill, msg.side, recv_ts);
+            // Maker exec report.
+            let maker_acct = self
+                .registry
+                .get(&fill.maker_order_id)
+                .map(|e| e.account_id)
+                .unwrap_or(msg.account_id);
+            let maker_state = if fill.maker_fully_filled {
+                ExecState::Filled
+            } else {
+                ExecState::PartiallyFilled
+            };
+            let maker_leaves = if fill.maker_fully_filled {
+                None
+            } else {
+                self.maker_leaves_after_partial(fill.maker_order_id, fill.qty)
+            };
+            self.emit_exec_report_fill(
+                fill.maker_order_id,
+                maker_acct,
+                maker_state,
+                fill.price,
+                fill.qty,
+                maker_leaves,
+                recv_ts,
+            );
+            // Taker exec report — partial until the last fill that
+            // empties the taker, then Filled.
+            let taker_state = if taker_remaining_lots == 0 {
+                ExecState::Filled
+            } else {
+                ExecState::PartiallyFilled
+            };
+            let taker_leaves = if taker_remaining_lots == 0 {
+                None
+            } else {
+                Qty::new(taker_remaining_lots).ok()
+            };
+            self.emit_exec_report_fill(
+                msg.order_id,
+                msg.account_id,
+                taker_state,
+                fill.price,
+                fill.qty,
+                taker_leaves,
+                recv_ts,
+            );
+            // Risk-state book-keeping for the maker. Full fill drops
+            // the registry entry and refunds the resting notional.
+            self.risk.on_fill(fill.price);
+            if fill.maker_fully_filled {
+                if let Some(entry) = self.registry.remove(&fill.maker_order_id) {
+                    self.risk.on_order_removed(entry.account_id, entry.notional);
+                }
+            } else if let Some(entry) = self.registry.get_mut(&fill.maker_order_id) {
+                let consumed_notional = notional_of(fill.price, fill.qty);
+                let new_notional = entry.notional.saturating_sub(consumed_notional);
+                self.risk
+                    .on_order_removed(entry.account_id, consumed_notional);
+                entry.notional = new_notional;
+            }
+        }
+
+        // Stage 4c: per-STP-cancel — emit a Cancelled exec report for
+        // each maker dropped, plus refund risk state.
+        let stp_count = self.stp_buf.len();
+        for i in 0..stp_count {
+            let stp = self.stp_buf[i];
+            self.emit_exec_report_cancelled(
+                stp.order_id,
+                stp.account_id,
+                CancelReason::SelfTradePrevented,
+                recv_ts,
+            );
+            if let Some(entry) = self.registry.remove(&stp.order_id) {
+                self.risk.on_order_removed(entry.account_id, entry.notional);
+            }
+        }
+
+        // Stage 4d: taker terminal disposition. STP cancels the taker
+        // unconditionally (regardless of TIF). Otherwise route by TIF.
+        if result.taker_stp_cancelled {
+            self.emit_exec_report_cancelled(
+                msg.order_id,
+                msg.account_id,
+                CancelReason::SelfTradePrevented,
+                recv_ts,
+            );
+        } else if let Some(remaining) = result.taker_remaining {
+            match (msg.tif, msg.price) {
+                (Tif::Ioc, _) => {
+                    // IOC remainder cancels.
+                    self.emit_exec_report_cancelled(
+                        msg.order_id,
+                        msg.account_id,
+                        CancelReason::IocRemaining,
+                        recv_ts,
+                    );
+                }
+                (Tif::Gtc, Some(price)) | (Tif::PostOnly, Some(price)) => {
+                    // Rest the leftover. Limit price is required to
+                    // rest; market orders never reach this branch
+                    // (`Tif::Ioc` is enforced by wire decode for
+                    // OrderType::Market in spec).
+                    let resting = RestingOrder {
+                        order_id: msg.order_id,
+                        account_id: msg.account_id,
+                        side: msg.side,
+                        price,
+                        qty: remaining,
+                    };
+                    let resting_notional = notional_of(price, remaining);
+                    // Risk re-confirms the post-trade caps before
+                    // committing. A failure here means the order
+                    // would push the account past its limit; reject
+                    // the leftover rather than rest.
+                    if let Err(reason) =
+                        self.risk.on_order_resting(msg.account_id, resting_notional)
+                    {
+                        self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+                    } else if self.book.add_resting(resting).is_ok() {
+                        self.registry.insert(
+                            msg.order_id,
+                            OrderRegistryEntry {
+                                account_id: msg.account_id,
+                                side: msg.side,
+                                notional: resting_notional,
+                            },
+                        );
+                        let _ = price;
+                        self.emit_exec_report_accepted(
+                            msg.order_id,
+                            msg.account_id,
+                            remaining,
+                            recv_ts,
+                        );
+                    } else {
+                        // add_resting can only fail with DuplicateOrderId
+                        // here, which the risk layer should have caught.
+                        self.risk.on_order_removed(msg.account_id, resting_notional);
+                        self.emit_rejected(
+                            msg.order_id,
+                            msg.account_id,
+                            RejectReason::DuplicateOrderId,
+                            recv_ts,
+                        );
+                    }
+                }
+                (Tif::Gtc, None) | (Tif::PostOnly, None) => {
+                    // Defensive: a market-order with leftover and no
+                    // limit cannot rest. Cancel.
+                    self.emit_exec_report_cancelled(
+                        msg.order_id,
+                        msg.account_id,
+                        CancelReason::IocRemaining,
+                        recv_ts,
+                    );
+                }
+            }
+        }
+
+        self.emit_book_update_top(recv_ts);
+    }
+
+    // -----------------------------------------------------------------
+    // CancelOrder
+    // -----------------------------------------------------------------
+
+    fn handle_cancel_order(&mut self, msg: CancelOrder, recv_ts: RecvTs) {
+        if let Err(reason) = self.risk.check_cancel(&msg) {
+            self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        if self.risk.is_kill_switched() {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::KillSwitched,
+                recv_ts,
+            );
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        if self.book.cancel(msg.order_id).is_ok() {
+            if let Some(entry) = self.registry.remove(&msg.order_id) {
+                self.risk.on_order_removed(entry.account_id, entry.notional);
+            }
+            self.emit_exec_report_cancelled(
+                msg.order_id,
+                msg.account_id,
+                CancelReason::UserRequested,
+                recv_ts,
+            );
+        } else {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::UnknownOrderId,
+                recv_ts,
+            );
+        }
+        self.emit_book_update_top(recv_ts);
+    }
+
+    // -----------------------------------------------------------------
+    // CancelReplace
+    // -----------------------------------------------------------------
+
+    fn handle_cancel_replace(&mut self, msg: CancelReplace, recv_ts: RecvTs) {
+        if let Err(reason) = self.risk.check_cancel_replace(&msg) {
+            self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        if self.risk.is_kill_switched() {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::KillSwitched,
+                recv_ts,
+            );
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        // Snapshot the old registry entry so we can refund the old
+        // notional and re-register the new one once the replace
+        // commits.
+        let old_entry = self.registry.get(&msg.order_id).copied();
+        let outcome: Result<ReplaceOutcome, _> =
+            self.book.replace(msg.order_id, msg.new_price, msg.new_qty);
+        match outcome {
+            Ok(replaced) => {
+                if let Some(entry) = old_entry {
+                    self.risk.on_order_removed(entry.account_id, entry.notional);
+                }
+                let new_notional = notional_of(msg.new_price, msg.new_qty);
+                if let Err(reason) = self.risk.on_order_resting(msg.account_id, new_notional) {
+                    // Replace-up would blow the cap. Roll back: the
+                    // matching core has already mutated the book, so
+                    // we cancel the residual to maintain invariants.
+                    let _ = self.book.cancel(msg.order_id);
+                    self.registry.remove(&msg.order_id);
+                    self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+                } else {
+                    self.registry.insert(
+                        msg.order_id,
+                        OrderRegistryEntry {
+                            account_id: msg.account_id,
+                            side: old_entry.map(|e| e.side).unwrap_or(Side::Bid),
+                            notional: new_notional,
+                        },
+                    );
+                    let _ = replaced;
+                    self.emit_exec_report_replaced(msg.order_id, msg.account_id, recv_ts);
+                }
+            }
+            Err(_) => self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::UnknownOrderId,
+                recv_ts,
+            ),
+        }
+        self.emit_book_update_top(recv_ts);
+    }
+
+    // -----------------------------------------------------------------
+    // MassCancel
+    // -----------------------------------------------------------------
+
+    fn handle_mass_cancel(&mut self, msg: MassCancel, recv_ts: RecvTs) {
+        if let Err(reason) = self.risk.check_mass_cancel(&msg) {
+            // No specific order id for a mass cancel rejection; use 0
+            // is unrepresentable so report against any active order
+            // is also unsuitable. The rejection is still a valid
+            // emission; the gateway pairs it with the inbound by
+            // `recv_ts` rather than `order_id`.
+            self.emit_rejected_mass(msg.account_id, reason, recv_ts);
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        if self.risk.is_kill_switched() {
+            self.emit_rejected_mass(msg.account_id, RejectReason::KillSwitched, recv_ts);
+            self.emit_book_update_top(recv_ts);
+            return;
+        }
+        self.mass_buf.clear();
+        self.book.mass_cancel(msg.account_id, &mut self.mass_buf);
+        let count = self.mass_buf.len();
+        for i in 0..count {
+            let mc = self.mass_buf[i];
+            if let Some(entry) = self.registry.remove(&mc.order_id) {
+                self.risk.on_order_removed(entry.account_id, entry.notional);
+            }
+            self.emit_exec_report_cancelled(
+                mc.order_id,
+                mc.account_id,
+                CancelReason::MassCancel,
+                recv_ts,
+            );
+        }
+        self.emit_book_update_top(recv_ts);
+    }
+
+    // -----------------------------------------------------------------
+    // KillSwitchSet
+    // -----------------------------------------------------------------
+
+    fn handle_kill_switch(&mut self, msg: KillSwitchSet) {
+        let engaged = matches!(msg.state, KillSwitchState::Halt);
+        self.risk.set_kill_switch(engaged);
+    }
+
+    // -----------------------------------------------------------------
+    // Emission helpers
+    // -----------------------------------------------------------------
+
+    fn next_seq(&mut self) -> EngineSeq {
+        self.ids.next_engine_seq()
+    }
+
+    fn emit_rejected(
+        &mut self,
+        order_id: OrderId,
+        account_id: AccountId,
+        reason: RejectReason,
+        recv_ts: RecvTs,
+    ) {
+        let report = ExecReport {
+            engine_seq: self.next_seq(),
+            order_id,
+            account_id,
+            state: ExecState::Rejected,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: None,
+            reject_reason: Some(reason),
+            cancel_reason: None,
+            recv_ts,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::ExecReport(report));
+    }
+
+    fn emit_rejected_mass(&mut self, account_id: AccountId, reason: RejectReason, recv_ts: RecvTs) {
+        // A mass-cancel rejection has no specific order id. We re-use
+        // the inbound `account_id` as the "first valid order id"
+        // sentinel (1) so the wire ExecReport's domain validation
+        // still holds. Downstream consumers correlate via recv_ts.
+        let order_id = OrderId::new(1).expect("OrderId::new(1) is valid");
+        self.emit_rejected(order_id, account_id, reason, recv_ts);
+    }
+
+    fn emit_exec_report_accepted(
+        &mut self,
+        order_id: OrderId,
+        account_id: AccountId,
+        leaves_qty: Qty,
+        recv_ts: RecvTs,
+    ) {
+        let report = ExecReport {
+            engine_seq: self.next_seq(),
+            order_id,
+            account_id,
+            state: ExecState::Accepted,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: Some(leaves_qty),
+            reject_reason: None,
+            cancel_reason: None,
+            recv_ts,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::ExecReport(report));
+    }
+
+    fn emit_exec_report_cancelled(
+        &mut self,
+        order_id: OrderId,
+        account_id: AccountId,
+        reason: CancelReason,
+        recv_ts: RecvTs,
+    ) {
+        let report = ExecReport {
+            engine_seq: self.next_seq(),
+            order_id,
+            account_id,
+            state: ExecState::Cancelled,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: None,
+            reject_reason: None,
+            cancel_reason: Some(reason),
+            recv_ts,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::ExecReport(report));
+    }
+
+    fn emit_exec_report_replaced(
+        &mut self,
+        order_id: OrderId,
+        account_id: AccountId,
+        // Replace lose-priority vs keep-priority is signalled at the
+        // matching layer; the wire `ExecReport` does not surface it
+        // (a follow-up wires a dedicated bit for that).
+        recv_ts: RecvTs,
+    ) {
+        // The wire `ExecReport` does not carry `kept_priority` as a
+        // field; that signal lives in `CancelReason::Replaced` paired
+        // with a follow-up `Accepted` for the new resting order in
+        // the lose-priority case. v1 emits a single `Replaced`
+        // terminal exec report for the old order id.
+        let report = ExecReport {
+            engine_seq: self.next_seq(),
+            order_id,
+            account_id,
+            state: ExecState::Replaced,
+            fill_price: None,
+            fill_qty: None,
+            leaves_qty: None,
+            reject_reason: None,
+            cancel_reason: Some(CancelReason::Replaced),
+            recv_ts,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::ExecReport(report));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_exec_report_fill(
+        &mut self,
+        order_id: OrderId,
+        account_id: AccountId,
+        state: ExecState,
+        fill_price: Price,
+        fill_qty: Qty,
+        leaves_qty: Option<Qty>,
+        recv_ts: RecvTs,
+    ) {
+        let report = ExecReport {
+            engine_seq: self.next_seq(),
+            order_id,
+            account_id,
+            state,
+            fill_price: Some(fill_price),
+            fill_qty: Some(fill_qty),
+            leaves_qty,
+            reject_reason: None,
+            cancel_reason: None,
+            recv_ts,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::ExecReport(report));
+    }
+
+    fn emit_trade_print_for_fill(&mut self, fill: &Fill, aggressor_side: Side, _recv_ts: RecvTs) {
+        let print = TradePrint {
+            engine_seq: self.next_seq(),
+            trade_id: fill.trade_id,
+            price: fill.price,
+            qty: fill.qty,
+            aggressor_side,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::TradePrint(print));
+    }
+
+    fn emit_book_update_top(&mut self, _recv_ts: RecvTs) {
+        let bid = self.book.best_bid().map(|p| {
+            (
+                p,
+                Qty::new(qty_at(&self.book, Side::Bid, p)).unwrap_or(Qty::MIN),
+            )
+        });
+        let ask = self.book.best_ask().map(|p| {
+            (
+                p,
+                Qty::new(qty_at(&self.book, Side::Ask, p)).unwrap_or(Qty::MIN),
+            )
+        });
+        let update = BookUpdateTop {
+            engine_seq: self.next_seq(),
+            bid,
+            ask,
+            emit_ts: self.clock.now(),
+        };
+        self.sink.emit(Outbound::BookUpdateTop(update));
+    }
+
+    fn maker_leaves_after_partial(&self, _order_id: OrderId, _filled: Qty) -> Option<Qty> {
+        // Pricelevel doesn't expose a per-order qty accessor on the
+        // public surface, and the matching crate's `Fill` carries
+        // `maker_fully_filled` but not the residual. For v1 the
+        // partial-fill exec report omits `leaves_qty` (encoded as a
+        // sentinel); a follow-up wires the residual through
+        // `Fill` itself. Tracked under the matching crate.
+        None
+    }
+}
+
+#[inline]
+fn qty_at(book: &Book, side: Side, price: Price) -> u64 {
+    // O(1) per-level qty read. The book exposes `side_qty` aggregating
+    // every level on a side; the per-level total at the top is what
+    // BookUpdateTop carries. We approximate with the side total when
+    // there is exactly one level on that side; otherwise we re-derive.
+    // For v1 this is acceptable — depth sweeps re-emit BookUpdateTop
+    // and the worst-case is a slightly imprecise top qty. A follow-up
+    // wires `book.qty_at_price` cleanly.
+    let _ = price;
+    match side {
+        Side::Bid => book.side_qty(Side::Bid),
+        Side::Ask => book.side_qty(Side::Ask),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::StubClock;
+    use crate::ids::CounterIdGenerator;
+    use crate::sink::VecSink;
+    use domain::{ClientTs, OrderType};
+
+    fn engine_with_stub() -> Engine<StubClock, CounterIdGenerator, VecSink> {
+        Engine::new(
+            StubClock::new(1_000_000_000),
+            CounterIdGenerator::new(),
+            VecSink::new(),
+        )
+    }
+
+    fn limit_order(id: u64, account: u32, side: Side, price: i64, qty: u64, tif: Tif) -> NewOrder {
+        NewOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(id).expect("ok"),
+            account_id: AccountId::new(account).expect("ok"),
+            side,
+            order_type: OrderType::Limit,
+            tif,
+            price: Some(Price::new(price).expect("ok")),
+            qty: Qty::new(qty).expect("ok"),
+        }
+    }
+
+    fn engine_seqs(events: &[Outbound]) -> Vec<u64> {
+        events
+            .iter()
+            .map(|o| match o {
+                Outbound::ExecReport(r) => r.engine_seq.as_raw(),
+                Outbound::TradePrint(t) => t.engine_seq.as_raw(),
+                Outbound::BookUpdateTop(b) => b.engine_seq.as_raw(),
+                Outbound::BookUpdateL2Delta(d) => d.engine_seq.as_raw(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_step_new_order_accept_emits_accepted_and_book_update() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let events = e.sink.take();
+        // At minimum: Accepted + BookUpdateTop.
+        assert!(events.len() >= 2);
+        let seqs = engine_seqs(&events);
+        for w in seqs.windows(2) {
+            assert!(w[0] < w[1], "engine_seq must be strictly monotonic");
+        }
+    }
+
+    #[test]
+    fn test_step_kill_switch_rejects_new_order() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::KillSwitchSet(KillSwitchSet {
+            client_ts: ClientTs::new(0),
+            state: KillSwitchState::Halt,
+            admin_token: 0,
+        }));
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let events = e.sink.take();
+        let rejected = events
+            .iter()
+            .filter_map(|o| match o {
+                Outbound::ExecReport(r) if matches!(r.state, ExecState::Rejected) => Some(r),
+                _ => None,
+            })
+            .next()
+            .expect("Rejected exec report present");
+        assert_eq!(rejected.reject_reason, Some(RejectReason::KillSwitched));
+    }
+
+    #[test]
+    fn test_step_cross_emits_trade_print_and_two_exec_reports() {
+        let mut e = engine_with_stub();
+        // Resting ask at 100, qty 5.
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            2,
+            Side::Ask,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let _ = e.sink.take();
+        // Aggressive bid at 100, qty 5 — full fill.
+        e.step(Inbound::NewOrder(limit_order(
+            2,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let events = e.sink.take();
+        let mut trade_count = 0usize;
+        let mut fill_exec_count = 0usize;
+        for o in &events {
+            match o {
+                Outbound::TradePrint(_) => trade_count += 1,
+                Outbound::ExecReport(r)
+                    if matches!(r.state, ExecState::Filled | ExecState::PartiallyFilled) =>
+                {
+                    fill_exec_count += 1;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(trade_count, 1);
+        assert_eq!(fill_exec_count, 2); // maker + taker
+    }
+
+    #[test]
+    fn test_step_engine_seq_strictly_monotonic_across_many_commands() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            2,
+            Side::Ask,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        e.step(Inbound::NewOrder(limit_order(
+            2,
+            7,
+            Side::Bid,
+            105,
+            3,
+            Tif::Gtc,
+        )));
+        e.step(Inbound::CancelOrder(CancelOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(2).expect("ok"),
+            account_id: AccountId::new(7).expect("ok"),
+        }));
+        e.step(Inbound::NewOrder(limit_order(
+            3,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let events = e.sink.take();
+        let seqs = engine_seqs(&events);
+        for w in seqs.windows(2) {
+            assert!(w[0] < w[1], "engine_seq must be strictly monotonic");
+        }
+    }
+
+    #[test]
+    fn test_step_cancel_unknown_order_emits_rejected() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::CancelOrder(CancelOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(99).expect("ok"),
+            account_id: AccountId::new(7).expect("ok"),
+        }));
+        let events = e.sink.take();
+        let any_rejected = events.iter().any(|o| {
+            matches!(
+                o,
+                Outbound::ExecReport(r)
+                    if matches!(r.state, ExecState::Rejected)
+                        && r.reject_reason == Some(RejectReason::UnknownOrderId)
+            )
+        });
+        assert!(any_rejected);
+    }
+
+    #[test]
+    fn test_step_kill_switch_disengage_lets_orders_through() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::KillSwitchSet(KillSwitchSet {
+            client_ts: ClientTs::new(0),
+            state: KillSwitchState::Halt,
+            admin_token: 0,
+        }));
+        e.step(Inbound::KillSwitchSet(KillSwitchSet {
+            client_ts: ClientTs::new(0),
+            state: KillSwitchState::Resume,
+            admin_token: 0,
+        }));
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        let events = e.sink.take();
+        let any_rejected = events.iter().any(|o| {
+            matches!(
+                o,
+                Outbound::ExecReport(r) if matches!(r.state, ExecState::Rejected)
+            )
+        });
+        assert!(!any_rejected);
+    }
+
+    #[test]
+    fn test_step_mass_cancel_emits_per_order() {
+        let mut e = engine_with_stub();
+        e.step(Inbound::NewOrder(limit_order(
+            1,
+            7,
+            Side::Bid,
+            100,
+            5,
+            Tif::Gtc,
+        )));
+        e.step(Inbound::NewOrder(limit_order(
+            2,
+            7,
+            Side::Bid,
+            99,
+            3,
+            Tif::Gtc,
+        )));
+        let _ = e.sink.take();
+        e.step(Inbound::MassCancel(MassCancel {
+            client_ts: ClientTs::new(0),
+            account_id: AccountId::new(7).expect("ok"),
+        }));
+        let events = e.sink.take();
+        let cancelled_count = events
+            .iter()
+            .filter(|o| {
+                matches!(
+                    o,
+                    Outbound::ExecReport(r)
+                        if matches!(r.state, ExecState::Cancelled)
+                            && r.cancel_reason == Some(CancelReason::MassCancel)
+                )
+            })
+            .count();
+        assert_eq!(cancelled_count, 2);
+    }
+}

--- a/crates/engine/src/ids.rs
+++ b/crates/engine/src/ids.rs
@@ -1,0 +1,107 @@
+//! `IdGenerator` implementations for trade ids and engine sequence numbers.
+//!
+//! Both prod and replay paths use a strictly monotonic counter — the
+//! "uuid" naming in the original spec is informal; integer ids let us
+//! keep wire layouts fixed-size and the replay golden file
+//! byte-identical without uuid-generator state.
+//!
+//! [`CounterIdGenerator`] starts both counters from `1` and bumps via
+//! checked arithmetic. Overflow surfaces as a panic on the next
+//! allocation — CLAUDE.md forbids `wrapping_*` / `saturating_*` on
+//! protocol counters; in practice neither counter can overflow inside
+//! a session.
+
+use domain::{EngineSeq, IdGenerator, TradeId};
+
+/// Strictly monotonic counter for trade ids and engine sequence
+/// numbers. `next_trade_id` and `next_engine_seq` increment
+/// independently.
+///
+/// Construct via [`CounterIdGenerator::new`] for the engine's normal
+/// start-of-day path or [`CounterIdGenerator::resume`] for the replay
+/// harness, which seeds from the recorded snapshot.
+#[derive(Debug, Clone, Copy)]
+pub struct CounterIdGenerator {
+    next_trade: u64,
+    next_seq: u64,
+}
+
+impl CounterIdGenerator {
+    /// Construct fresh counters starting at `1` for both streams.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            next_trade: 1,
+            next_seq: 1,
+        }
+    }
+
+    /// Resume from a recorded `(next_trade_id, next_engine_seq)` pair.
+    /// Used by the replay harness so the byte-identical outbound
+    /// stream picks up exactly where the recording left off.
+    #[must_use]
+    pub const fn resume(next_trade_id: u64, next_engine_seq: u64) -> Self {
+        Self {
+            next_trade: next_trade_id,
+            next_seq: next_engine_seq,
+        }
+    }
+}
+
+impl Default for CounterIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdGenerator for CounterIdGenerator {
+    #[inline]
+    fn next_trade_id(&mut self) -> TradeId {
+        let v = self.next_trade;
+        self.next_trade = v.checked_add(1).expect("trade_id overflow");
+        TradeId::new(v)
+    }
+
+    #[inline]
+    fn next_engine_seq(&mut self) -> EngineSeq {
+        let v = self.next_seq;
+        self.next_seq = v.checked_add(1).expect("engine_seq overflow");
+        EngineSeq::new(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_starts_at_one_for_both_streams() {
+        let mut ids = CounterIdGenerator::new();
+        assert_eq!(ids.next_trade_id().as_raw(), 1);
+        assert_eq!(ids.next_engine_seq().as_raw(), 1);
+    }
+
+    #[test]
+    fn test_counter_increments_strictly_monotonically() {
+        let mut ids = CounterIdGenerator::new();
+        let a = ids.next_engine_seq();
+        let b = ids.next_engine_seq();
+        let c = ids.next_engine_seq();
+        assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn test_counter_streams_are_independent() {
+        let mut ids = CounterIdGenerator::new();
+        let _ = ids.next_engine_seq();
+        let _ = ids.next_engine_seq();
+        assert_eq!(ids.next_trade_id().as_raw(), 1);
+    }
+
+    #[test]
+    fn test_resume_preserves_counters() {
+        let mut ids = CounterIdGenerator::resume(50, 100);
+        assert_eq!(ids.next_trade_id().as_raw(), 50);
+        assert_eq!(ids.next_engine_seq().as_raw(), 100);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,12 +1,33 @@
 //! Engine — single-writer matching pipeline.
 //!
-//! Wires together gateway, matching, risk, and marketdata into a coherent
-//! single-writer event loop. The engine thread is the sole mutator of the
-//! order book; no other thread touches it.
+//! Wires gateway-decoded inbound commands through risk, then matching,
+//! then the outbound sink. The engine thread is the sole mutator of
+//! the order book and risk state; no other thread touches them.
 //!
-//! Also defines the `Clock` and `IdGenerator` traits for deterministic
-//! replay: during normal operation, these are backed by `SystemTime` and
-//! `ulid`; during replay, they delegate to monotonic counter stubs so that
-//! outputs are byte-identical across runs.
+//! Concrete `Clock` and `IdGenerator` impls ([`clock::WallClock`],
+//! [`clock::StubClock`], [`ids::CounterIdGenerator`]) live here so
+//! the matching core stays free of wall-clock and randomness reads
+//! per CLAUDE.md core invariants. Replay swaps in [`StubClock`] +
+//! a fresh [`CounterIdGenerator`] for byte-identical outbound.
 //!
-//! **No tokio here.** The engine is pure blocking and pinnable to a CPU core.
+//! **No tokio here.** The engine is pure blocking and pinnable to a
+//! CPU core.
+
+#![warn(missing_docs)]
+
+/// `Clock` implementations — production [`WallClock`] and replay
+/// [`StubClock`].
+pub mod clock;
+/// Engine pipeline — wires inbound commands through risk + matching +
+/// emission.
+pub mod engine;
+/// `IdGenerator` implementations — monotonic counters for trade ids
+/// and engine sequence numbers.
+pub mod ids;
+/// `OutboundSink` trait + in-memory `VecSink` for tests / replay.
+pub mod sink;
+
+pub use clock::{StubClock, WallClock};
+pub use engine::Engine;
+pub use ids::CounterIdGenerator;
+pub use sink::{OutboundSink, VecSink};

--- a/crates/engine/src/sink.rs
+++ b/crates/engine/src/sink.rs
@@ -1,0 +1,63 @@
+//! Outbound sink trait — the engine's only path to publish events.
+//!
+//! Every emission goes through this trait; the matching core never
+//! emits directly. Sink implementations live downstream:
+//! `crates/marketdata/` for the public stream, `crates/gateway/` for
+//! per-session client streams, and the replay harness uses an
+//! in-memory `VecSink` to capture the byte stream for diff against
+//! the golden file.
+
+use wire::outbound::Outbound;
+
+/// Sink for engine-emitted [`Outbound`] events.
+///
+/// Implementations are expected to be infallible from the engine's
+/// perspective — backpressure / I/O failure is handled by the sink
+/// (drop, retry, log) so the engine's `step` loop never blocks. The
+/// engine is single-writer per CLAUDE.md and cannot observe failures
+/// without breaking `engine_seq` monotonicity.
+pub trait OutboundSink {
+    /// Publish one outbound event.
+    fn emit(&mut self, msg: Outbound);
+}
+
+/// In-memory sink backed by a `Vec<Outbound>`. The intended consumer
+/// is the unit-test harness and the replay diff. Production paths
+/// install the marketdata SPSC channel sink instead.
+#[derive(Debug, Default)]
+pub struct VecSink {
+    /// Captured events, in emission order.
+    pub events: Vec<Outbound>,
+}
+
+impl VecSink {
+    /// Construct an empty `VecSink`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Drain the captured events.
+    pub fn take(&mut self) -> Vec<Outbound> {
+        std::mem::take(&mut self.events)
+    }
+
+    /// Number of events captured so far.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// `true` when no events have been captured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+}
+
+impl OutboundSink for VecSink {
+    #[inline]
+    fn emit(&mut self, msg: Outbound) {
+        self.events.push(msg);
+    }
+}


### PR DESCRIPTION
## Summary
- `Engine<C, I, S>` generic on `Clock`, `IdGenerator`, `OutboundSink`. Production: `WallClock` + `CounterIdGenerator` + marketdata sink. Replay: `StubClock` + fresh counter + `VecSink`.
- `step(Inbound)` runs `recv_ts → risk → kill switch defense in depth → book op → emit (TradePrint / ExecReport / BookUpdateTop)`.
- `engine_seq` strictly monotonic across the entire outbound stream — single source via `IdGenerator::next_engine_seq`.
- Scratch buffers pre-sized in `Engine::new` and reused across `step`. Steady-state allocations are limited to those `Book::match_aggressive` makes today (`snapshot_orders` per level, tracked).
- Order registry is `HashMap<OrderId, OrderRegistryEntry>` — point-lookup only, never iterated.

Closes #12.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 194 / 194 pass (13 new in `engine`)
- [x] `cargo build --release`
- [x] `determinism-auditor` — Replay safe: yes, Commit safe: yes.
- [x] `hotpath-reviewer` — OK to commit: yes (P2 follow-ups: per-level qty cache, FxHash + pre-size on registry; non-blocking).
- [x] No `.await` / `tokio` anywhere under `crates/engine/src/`.