### PR TITLE
feat(wire, engine): SnapshotResponse + control-plane handler (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,7 @@ encoders, decoders, and roundtrip tests.
 | 102  | 0x66  | `TradePrint`        | 48 bytes     | Public trade emission                              |
 | 103  | 0x67  | `BookUpdateTop`     | 48 bytes     | Top-of-book on every book change                   |
 | 104  | 0x68  | `BookUpdateL2Delta` | 40 bytes     | Per-level depth delta (level removed when `new_qty = 0`) |
-
-`SnapshotResponse` (105) is intentionally absent from the bespoke
-fixed-size pattern; the variable-length book depth array lives behind a
-separate framing scheme to be added under a later issue.
+| 105  | 0x69  | `SnapshotResponse`  | variable     | Variable-length book + engine state dump in response to `SnapshotRequest`. Layout: `[engine_seq u64][request_id u64][recv_ts u64][emit_ts u64][n_bid u32][n_ask u32][bid levels][ask levels]`, each level `[price i64][qty u64]`. Bids best-first (descending), asks best-first (ascending). |
 
 ### Decode invariants
 

--- a/crates/engine/src/bin/replay.rs
+++ b/crates/engine/src/bin/replay.rs
@@ -131,6 +131,10 @@ fn zero_timestamps(ev: &mut Outbound) {
         Outbound::BookUpdateL2Delta(d) => {
             d.emit_ts = RecvTs::new(0);
         }
+        Outbound::SnapshotResponse(s) => {
+            s.recv_ts = RecvTs::new(0);
+            s.emit_ts = RecvTs::new(0);
+        }
     }
 }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -36,7 +36,9 @@ use matching::{
 use risk::{RiskState, notional_of};
 use wire::inbound::{
     CancelOrder, CancelReplace, Inbound, KillSwitchSet, KillSwitchState, MassCancel, NewOrder,
+    SnapshotRequest,
 };
+use wire::outbound::snapshot_response::{Level as SnapshotLevel, SnapshotResponse};
 use wire::outbound::{BookUpdateTop, ExecReport, Outbound, TradePrint};
 
 use marketdata::OutboundSink;
@@ -139,10 +141,36 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             Inbound::CancelReplace(msg) => self.handle_cancel_replace(msg, recv_ts),
             Inbound::MassCancel(msg) => self.handle_mass_cancel(msg, recv_ts),
             Inbound::KillSwitchSet(msg) => self.handle_kill_switch(msg),
-            // SnapshotRequest support is intentionally deferred —
-            // tracked separately under the marketdata snapshot work.
-            Inbound::SnapshotRequest(_) => {}
+            Inbound::SnapshotRequest(msg) => self.handle_snapshot_request(msg, recv_ts),
         }
+    }
+
+    fn handle_snapshot_request(&mut self, msg: SnapshotRequest, recv_ts: RecvTs) {
+        // Walk the book in deterministic best-first order. Empty
+        // levels are filtered (`total_quantity()` may transiently
+        // report 0 during pricelevel's lazy cleanup; replay must
+        // not see phantom levels).
+        let bids: Vec<SnapshotLevel> = self
+            .book
+            .bid_levels()
+            .filter(|(_, qty)| *qty > 0)
+            .filter_map(|(price, qty)| Qty::new(qty).ok().map(|q| SnapshotLevel { price, qty: q }))
+            .collect();
+        let asks: Vec<SnapshotLevel> = self
+            .book
+            .ask_levels()
+            .filter(|(_, qty)| *qty > 0)
+            .filter_map(|(price, qty)| Qty::new(qty).ok().map(|q| SnapshotLevel { price, qty: q }))
+            .collect();
+        let response = SnapshotResponse {
+            engine_seq: self.next_seq(),
+            request_id: msg.request_id,
+            recv_ts,
+            emit_ts: self.clock.now(),
+            bids,
+            asks,
+        };
+        self.sink.emit(Outbound::SnapshotResponse(response));
     }
 
     // -----------------------------------------------------------------
@@ -779,6 +807,7 @@ mod tests {
                 Outbound::TradePrint(t) => t.engine_seq.as_raw(),
                 Outbound::BookUpdateTop(b) => b.engine_seq.as_raw(),
                 Outbound::BookUpdateL2Delta(d) => d.engine_seq.as_raw(),
+                Outbound::SnapshotResponse(s) => s.engine_seq.as_raw(),
             })
             .collect()
     }

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -75,6 +75,7 @@ fn smoke_100_orders_engine_seq_is_strictly_monotonic_after_decode() {
             Outbound::TradePrint(t) => t.engine_seq.as_raw(),
             Outbound::BookUpdateTop(b) => b.engine_seq.as_raw(),
             Outbound::BookUpdateL2Delta(d) => d.engine_seq.as_raw(),
+            Outbound::SnapshotResponse(s) => s.engine_seq.as_raw(),
         };
         assert!(
             seq > last_seq,
@@ -125,6 +126,96 @@ fn smoke_trade_print_emits_exactly_once_per_fill() {
         .filter(|o| matches!(o, Outbound::TradePrint(_)))
         .count();
     assert_eq!(trade_count, 2);
+}
+
+#[test]
+fn smoke_snapshot_request_returns_book_levels_in_best_first_order() {
+    use wire::inbound::SnapshotRequest;
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    // Bids: 100, 99, 95 (descending = best first).
+    engine.step(Inbound::NewOrder(limit_order(1, 7, Side::Bid, 99, 5)));
+    engine.step(Inbound::NewOrder(limit_order(2, 7, Side::Bid, 100, 3)));
+    engine.step(Inbound::NewOrder(limit_order(3, 7, Side::Bid, 95, 7)));
+    // Asks: 101, 105, 110 (ascending = best first).
+    engine.step(Inbound::NewOrder(limit_order(4, 2, Side::Ask, 110, 4)));
+    engine.step(Inbound::NewOrder(limit_order(5, 2, Side::Ask, 101, 6)));
+    engine.step(Inbound::NewOrder(limit_order(6, 2, Side::Ask, 105, 2)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    engine.step(Inbound::SnapshotRequest(SnapshotRequest { request_id: 42 }));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+    let snap = events
+        .iter()
+        .find_map(|o| match o {
+            Outbound::SnapshotResponse(s) => Some(s),
+            _ => None,
+        })
+        .expect("SnapshotResponse emitted");
+    assert_eq!(snap.request_id, 42);
+    let bid_prices: Vec<i64> = snap.bids.iter().map(|l| l.price.as_ticks()).collect();
+    let ask_prices: Vec<i64> = snap.asks.iter().map(|l| l.price.as_ticks()).collect();
+    assert_eq!(bid_prices, vec![100, 99, 95], "bids best-first");
+    assert_eq!(ask_prices, vec![101, 105, 110], "asks best-first");
+    let bid_qtys: Vec<u64> = snap.bids.iter().map(|l| l.qty.as_lots()).collect();
+    let ask_qtys: Vec<u64> = snap.asks.iter().map(|l| l.qty.as_lots()).collect();
+    assert_eq!(bid_qtys, vec![3, 5, 7]);
+    assert_eq!(ask_qtys, vec![6, 2, 4]);
+}
+
+#[test]
+fn smoke_snapshot_request_on_empty_book_returns_empty_levels() {
+    use wire::inbound::SnapshotRequest;
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    engine.step(Inbound::SnapshotRequest(SnapshotRequest { request_id: 1 }));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+    let snap = events
+        .iter()
+        .find_map(|o| match o {
+            Outbound::SnapshotResponse(s) => Some(s),
+            _ => None,
+        })
+        .expect("SnapshotResponse emitted");
+    assert!(snap.bids.is_empty());
+    assert!(snap.asks.is_empty());
+}
+
+#[test]
+fn smoke_snapshot_response_round_trips_through_marketdata_encoder() {
+    use wire::inbound::SnapshotRequest;
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    engine.step(Inbound::NewOrder(limit_order(1, 7, Side::Bid, 100, 5)));
+    engine.step(Inbound::NewOrder(limit_order(2, 2, Side::Ask, 101, 3)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    engine.step(Inbound::SnapshotRequest(SnapshotRequest { request_id: 9 }));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+    let original = events
+        .iter()
+        .find_map(|o| match o {
+            Outbound::SnapshotResponse(s) => Some(s.clone()),
+            _ => None,
+        })
+        .expect("snapshot present");
+    let mut bytes = Vec::new();
+    encoder::encode(&Outbound::SnapshotResponse(original.clone()), &mut bytes).expect("encode");
+    let (decoded, total) = encoder::decode(&bytes).expect("decode");
+    assert_eq!(total, bytes.len());
+    match decoded {
+        Outbound::SnapshotResponse(decoded) => assert_eq!(decoded, original),
+        _ => panic!("decoded variant mismatch"),
+    }
 }
 
 /// Helper to drain the inner `VecSink` from the typed `Engine`.

--- a/crates/marketdata/src/encoder.rs
+++ b/crates/marketdata/src/encoder.rs
@@ -11,7 +11,9 @@
 //! decoded frame; gap detection is built into the contract.
 
 use wire::framing::{Frame, MessageKind};
-use wire::outbound::{Outbound, book_update_l2_delta, book_update_top, exec_report, trade_print};
+use wire::outbound::{
+    Outbound, book_update_l2_delta, book_update_top, exec_report, snapshot_response, trade_print,
+};
 use wire::{WireError, framing};
 
 /// Encode one [`Outbound`] event into a framed byte sequence appended
@@ -40,6 +42,10 @@ pub fn encode(msg: &Outbound, out: &mut Vec<u8>) -> Result<(), WireError> {
         Outbound::BookUpdateL2Delta(d) => {
             book_update_l2_delta::encode(d, &mut payload);
             MessageKind::BookUpdateL2Delta
+        }
+        Outbound::SnapshotResponse(s) => {
+            snapshot_response::encode(s, &mut payload);
+            MessageKind::SnapshotResponse
         }
     };
     Frame::write(kind, &payload, out)?;

--- a/crates/matching/src/book.rs
+++ b/crates/matching/src/book.rs
@@ -637,6 +637,25 @@ impl Book {
         self.asks.keys().next().copied()
     }
 
+    /// Iterate the bid side as `(price, total_qty)` pairs in **best-first**
+    /// (descending price) order. Drives deterministic snapshot
+    /// emission — the underlying `BTreeMap` already iterates in sorted
+    /// order; we reverse for "best bid first".
+    pub fn bid_levels(&self) -> impl Iterator<Item = (Price, u64)> + '_ {
+        self.bids
+            .iter()
+            .rev()
+            .map(|(price, level)| (*price, level.total_quantity().unwrap_or(0)))
+    }
+
+    /// Iterate the ask side as `(price, total_qty)` pairs in **best-first**
+    /// (ascending price) order.
+    pub fn ask_levels(&self) -> impl Iterator<Item = (Price, u64)> + '_ {
+        self.asks
+            .iter()
+            .map(|(price, level)| (*price, level.total_quantity().unwrap_or(0)))
+    }
+
     /// Sum of resting quantity on a side, in lots. O(n) over the price
     /// levels; intended for tests and snapshots, not the hot path.
     #[must_use]

--- a/crates/wire/src/framing.rs
+++ b/crates/wire/src/framing.rs
@@ -43,6 +43,8 @@ pub enum MessageKind {
     BookUpdateTop = 0x67,
     /// `BookUpdateL2Delta` — per-level depth delta.
     BookUpdateL2Delta = 0x68,
+    /// `SnapshotResponse` — variable-length book + engine state dump.
+    SnapshotResponse = 0x69,
 }
 
 impl MessageKind {
@@ -69,6 +71,7 @@ impl TryFrom<u8> for MessageKind {
             0x66 => Ok(Self::TradePrint),
             0x67 => Ok(Self::BookUpdateTop),
             0x68 => Ok(Self::BookUpdateL2Delta),
+            0x69 => Ok(Self::SnapshotResponse),
             other => Err(WireError::UnknownKind(other)),
         }
     }

--- a/crates/wire/src/inbound/mod.rs
+++ b/crates/wire/src/inbound/mod.rs
@@ -63,6 +63,7 @@ pub fn parse_frame(frame: Frame<'_>) -> Result<Inbound, WireError> {
         outbound @ (MessageKind::ExecReport
         | MessageKind::TradePrint
         | MessageKind::BookUpdateTop
-        | MessageKind::BookUpdateL2Delta) => Err(WireError::UnknownKind(outbound.as_u8())),
+        | MessageKind::BookUpdateL2Delta
+        | MessageKind::SnapshotResponse) => Err(WireError::UnknownKind(outbound.as_u8())),
     }
 }

--- a/crates/wire/src/outbound/mod.rs
+++ b/crates/wire/src/outbound/mod.rs
@@ -1,23 +1,26 @@
 //! Outbound (engine → client / market-data) message types.
 //!
-//! Each submodule exposes a `parse(payload: &[u8]) -> Result<X, WireError>`
-//! and `encode(msg: &X, out: &mut Vec<u8>)` pair plus the
+//! Each fixed-size submodule exposes a
+//! `parse(payload: &[u8]) -> Result<X, WireError>` and
+//! `encode(msg: &X, out: &mut Vec<u8>)` pair plus the
 //! `XxxWire` `#[repr(C, packed)]` layout struct.
 //!
+//! [`snapshot_response`] is the only outbound message with a
+//! variable-length payload; its layout is documented in that
+//! module. The framing prefix is identical for every kind.
+//!
 //! [`Outbound`] is the dispatched union the marketdata sink consumes.
-//! `SnapshotResponse` (kind = 0x69 / 105) is intentionally absent —
-//! the variable-length book depth array conflicts with the bespoke
-//! fixed-size pattern this crate uses, so it lives behind a separate
-//! framing scheme to be added under a later issue.
 
 pub mod book_update_l2_delta;
 pub mod book_update_top;
 pub mod exec_report;
+pub mod snapshot_response;
 pub mod trade_print;
 
 pub use book_update_l2_delta::BookUpdateL2Delta;
 pub use book_update_top::BookUpdateTop;
 pub use exec_report::ExecReport;
+pub use snapshot_response::SnapshotResponse;
 pub use trade_print::TradePrint;
 
 use crate::WireError;
@@ -34,6 +37,8 @@ pub enum Outbound {
     BookUpdateTop(BookUpdateTop),
     /// `BookUpdateL2Delta` — per-level depth delta.
     BookUpdateL2Delta(BookUpdateL2Delta),
+    /// `SnapshotResponse` — variable-length book + engine state dump.
+    SnapshotResponse(SnapshotResponse),
 }
 
 /// Parse an outbound frame into its typed variant.
@@ -53,6 +58,9 @@ pub fn parse_frame(frame: Frame<'_>) -> Result<Outbound, WireError> {
         }
         MessageKind::BookUpdateL2Delta => {
             book_update_l2_delta::parse(frame.payload).map(Outbound::BookUpdateL2Delta)
+        }
+        MessageKind::SnapshotResponse => {
+            snapshot_response::parse(frame.payload).map(Outbound::SnapshotResponse)
         }
         inbound @ (MessageKind::NewOrder
         | MessageKind::CancelOrder

--- a/crates/wire/src/outbound/snapshot_response.rs
+++ b/crates/wire/src/outbound/snapshot_response.rs
@@ -1,0 +1,223 @@
+//! `SnapshotResponse` (kind = 0x69 / 105) — variable-length book +
+//! engine state dump emitted in response to an inbound
+//! `SnapshotRequest`.
+//!
+//! This is the only outbound message in v1 with a non-fixed payload
+//! length. Layout (all little-endian):
+//!
+//! ```text
+//! offset  size  field
+//! ------  ----  -----
+//!   0      8    engine_seq
+//!   8      8    request_id     (echoed from the request)
+//!  16      8    recv_ts        (engine-stamped from the request)
+//!  24      8    emit_ts        (engine-stamped at emission)
+//!  32      4    n_bid_levels   (u32 LE)
+//!  36      4    n_ask_levels   (u32 LE)
+//!  40      ?    bid levels  — best first (descending price)
+//!   ?      ?    ask levels  — best first (ascending price)
+//! ```
+//!
+//! Each level is `[i64 LE price][u64 LE qty]`, 16 bytes. Total payload
+//! size = `40 + 16 * (n_bid_levels + n_ask_levels)`.
+//!
+//! The framing prefix outside the payload is the standard
+//! `[u32 LE total][u8 kind = 0x69]`.
+
+use domain::{EngineSeq, Price, Qty, RecvTs};
+
+use crate::WireError;
+use crate::error::to_wire;
+
+/// Per-level entry in the snapshot — `(price, total_qty)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Level {
+    /// Price of the level.
+    pub price: Price,
+    /// Aggregate qty resting at this level.
+    pub qty: Qty,
+}
+
+/// Domain-typed snapshot response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotResponse {
+    /// Engine sequence number. Strictly monotonic across all outbound.
+    pub engine_seq: EngineSeq,
+    /// Echo of the request's correlation id.
+    pub request_id: u64,
+    /// Engine-stamped recv timestamp from the request.
+    pub recv_ts: RecvTs,
+    /// Engine-stamped emit timestamp at snapshot construction.
+    pub emit_ts: RecvTs,
+    /// Bid side, best first (descending price).
+    pub bids: Vec<Level>,
+    /// Ask side, best first (ascending price).
+    pub asks: Vec<Level>,
+}
+
+const HEADER_BYTES: usize = 40;
+const LEVEL_BYTES: usize = 16;
+
+/// Compute the encoded payload length without allocating.
+#[must_use]
+pub fn encoded_len(msg: &SnapshotResponse) -> usize {
+    HEADER_BYTES + LEVEL_BYTES * (msg.bids.len() + msg.asks.len())
+}
+
+/// Encode a snapshot into `out`. Appends `encoded_len(msg)` bytes.
+pub fn encode(msg: &SnapshotResponse, out: &mut Vec<u8>) {
+    out.extend_from_slice(&msg.engine_seq.as_raw().to_le_bytes());
+    out.extend_from_slice(&msg.request_id.to_le_bytes());
+    out.extend_from_slice(&(msg.recv_ts.as_nanos() as u64).to_le_bytes());
+    out.extend_from_slice(&(msg.emit_ts.as_nanos() as u64).to_le_bytes());
+    let n_bid = u32::try_from(msg.bids.len()).expect("level count fits in u32");
+    let n_ask = u32::try_from(msg.asks.len()).expect("level count fits in u32");
+    out.extend_from_slice(&n_bid.to_le_bytes());
+    out.extend_from_slice(&n_ask.to_le_bytes());
+    for level in &msg.bids {
+        out.extend_from_slice(&level.price.as_ticks().to_le_bytes());
+        out.extend_from_slice(&level.qty.as_lots().to_le_bytes());
+    }
+    for level in &msg.asks {
+        out.extend_from_slice(&level.price.as_ticks().to_le_bytes());
+        out.extend_from_slice(&level.qty.as_lots().to_le_bytes());
+    }
+}
+
+/// Decode a snapshot from a payload.
+///
+/// # Errors
+/// [`WireError::PayloadSize`] when the payload is shorter than the
+/// declared level count, or when the trailing bytes do not match
+/// `HEADER + LEVEL * (n_bid + n_ask)` exactly.
+/// [`WireError::Domain`] when a price / qty fails domain validation.
+pub fn parse(payload: &[u8]) -> Result<SnapshotResponse, WireError> {
+    if payload.len() < HEADER_BYTES {
+        return Err(WireError::PayloadSize {
+            expected: HEADER_BYTES,
+            got: payload.len(),
+        });
+    }
+    let engine_seq = EngineSeq::new(u64::from_le_bytes(
+        payload[0..8].try_into().expect("8 bytes"),
+    ));
+    let request_id = u64::from_le_bytes(payload[8..16].try_into().expect("8 bytes"));
+    let recv_ts =
+        RecvTs::new(u64::from_le_bytes(payload[16..24].try_into().expect("8 bytes")) as i64);
+    let emit_ts =
+        RecvTs::new(u64::from_le_bytes(payload[24..32].try_into().expect("8 bytes")) as i64);
+    let n_bid = u32::from_le_bytes(payload[32..36].try_into().expect("4 bytes")) as usize;
+    let n_ask = u32::from_le_bytes(payload[36..40].try_into().expect("4 bytes")) as usize;
+    let expected = HEADER_BYTES + LEVEL_BYTES * (n_bid + n_ask);
+    if payload.len() != expected {
+        return Err(WireError::PayloadSize {
+            expected,
+            got: payload.len(),
+        });
+    }
+    let mut bids = Vec::with_capacity(n_bid);
+    let mut asks = Vec::with_capacity(n_ask);
+    let mut cursor = HEADER_BYTES;
+    for _ in 0..n_bid {
+        let price_raw =
+            i64::from_le_bytes(payload[cursor..cursor + 8].try_into().expect("8 bytes"));
+        let qty_raw = u64::from_le_bytes(
+            payload[cursor + 8..cursor + 16]
+                .try_into()
+                .expect("8 bytes"),
+        );
+        bids.push(Level {
+            price: Price::new(price_raw).map_err(to_wire)?,
+            qty: Qty::new(qty_raw).map_err(to_wire)?,
+        });
+        cursor += LEVEL_BYTES;
+    }
+    for _ in 0..n_ask {
+        let price_raw =
+            i64::from_le_bytes(payload[cursor..cursor + 8].try_into().expect("8 bytes"));
+        let qty_raw = u64::from_le_bytes(
+            payload[cursor + 8..cursor + 16]
+                .try_into()
+                .expect("8 bytes"),
+        );
+        asks.push(Level {
+            price: Price::new(price_raw).map_err(to_wire)?,
+            qty: Qty::new(qty_raw).map_err(to_wire)?,
+        });
+        cursor += LEVEL_BYTES;
+    }
+    Ok(SnapshotResponse {
+        engine_seq,
+        request_id,
+        recv_ts,
+        emit_ts,
+        bids,
+        asks,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn level(price: i64, qty: u64) -> Level {
+        Level {
+            price: Price::new(price).expect("ok"),
+            qty: Qty::new(qty).expect("ok"),
+        }
+    }
+
+    fn sample() -> SnapshotResponse {
+        SnapshotResponse {
+            engine_seq: EngineSeq::new(42),
+            request_id: 7,
+            recv_ts: RecvTs::new(1_000),
+            emit_ts: RecvTs::new(1_001),
+            bids: vec![level(100, 5), level(99, 10)],
+            asks: vec![level(101, 3), level(102, 7), level(103, 2)],
+        }
+    }
+
+    #[test]
+    fn test_snapshot_response_roundtrip() {
+        let msg = sample();
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(buf.len(), encoded_len(&msg));
+        let decoded = parse(&buf).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn test_snapshot_response_empty_book() {
+        let msg = SnapshotResponse {
+            engine_seq: EngineSeq::new(1),
+            request_id: 0,
+            recv_ts: RecvTs::new(0),
+            emit_ts: RecvTs::new(0),
+            bids: Vec::new(),
+            asks: Vec::new(),
+        };
+        let mut buf = Vec::new();
+        encode(&msg, &mut buf);
+        assert_eq!(buf.len(), HEADER_BYTES);
+        let decoded = parse(&buf).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn test_snapshot_response_truncated_returns_size_err() {
+        let buf = [0u8; HEADER_BYTES - 1];
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+
+    #[test]
+    fn test_snapshot_response_invalid_level_count_returns_size_err() {
+        // Header declares 2 bid levels and 0 ask levels, but body has
+        // only 16 bytes (one level worth).
+        let mut buf = vec![0u8; HEADER_BYTES];
+        buf[32..36].copy_from_slice(&2u32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; LEVEL_BYTES]); // only 1 level body
+        assert!(matches!(parse(&buf), Err(WireError::PayloadSize { .. })));
+    }
+}


### PR DESCRIPTION
## Summary
- New outbound message kind `SnapshotResponse` (0x69 / 105) — the only variable-length payload in v1. Layout documented in module + README.
- `Book::bid_levels()` / `ask_levels()` iterators (best-first, BTreeMap-driven, deterministic).
- Engine `handle_snapshot_request` replaces the previous no-op; emits a typed `SnapshotResponse` with the same `engine_seq` monotonic invariant as every other event.
- 3 engine integration tests + 4 wire roundtrip tests.

Closes #42.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 228 / 228 pass.
- [x] `cargo build --release`
- [x] Replay golden still matches: `cargo run --release --bin replay -- fixtures/inbound.bin /tmp/out.bin --no-timestamps && diff /tmp/out.bin fixtures/outbound.golden`.
- [x] `determinism-auditor`: Replay safe / Commit safe both yes.
- [x] `hotpath-reviewer`: OK to commit.