### PR TITLE
feat(gateway, engine): outbound TCP fan-out per session (#43)

### DIFF
--- a/crates/engine/src/bin/engine.rs
+++ b/crates/engine/src/bin/engine.rs
@@ -1,6 +1,6 @@
 //! Engine binary. Tokio entry point that owns the gateway listener,
-//! a dedicated engine thread, and a `ChannelSink` fan-out for any
-//! per-session outbound writers added in follow-ups.
+//! a dedicated engine thread, and a `ChannelSink` broadcast that
+//! every accepted TCP session subscribes to.
 //!
 //! ## CLI
 //!
@@ -8,38 +8,33 @@
 //! engine [bind_addr]
 //! ```
 //!
-//! Default bind address `0.0.0.0:9000`. The engine logs accepted
-//! sessions to stderr; outbound events are encoded into the
-//! `ChannelSink`'s broadcast channel but the per-session writer
-//! tasks that subscribe and pump to TCP are out of scope for v1
-//! and tracked as a follow-up. The binary is the smallest end-to-
-//! end shape the docker compose smoke test exercises.
+//! Default bind address `0.0.0.0:9000`. Connected clients can
+//! submit framed inbound messages and read framed outbound bytes
+//! (`ExecReport` / `TradePrint` / `BookUpdateTop` / `SnapshotResponse`)
+//! on the same TCP connection.
+//!
+//! ## Backpressure
+//!
+//! - Inbound `tokio::sync::mpsc` is bounded at 8192. `try_send` Full
+//!   from the gateway closes the offending connection (fail-fast).
+//! - Outbound `tokio::sync::broadcast` is bounded at 1024 frames per
+//!   subscriber. A subscriber that lags by more than the buffer
+//!   receives `Lagged(_)` and the per-session writer task closes
+//!   the TCP connection. The engine never blocks on a slow
+//!   subscriber.
 
+use std::sync::Arc;
 use std::sync::mpsc;
 use std::thread;
 
-use engine::{CounterIdGenerator, Engine, OutboundSink, WallClock};
-use gateway::run;
+use engine::{CounterIdGenerator, Engine, WallClock};
+use gateway::{ChannelSink, run};
 use tokio::sync::mpsc as tmpsc;
 use wire::inbound::Inbound;
-use wire::outbound::Outbound;
 
 const DEFAULT_ADDR: &str = "0.0.0.0:9000";
-
-/// Drop-in sink that counts outbound events without holding them in
-/// memory. The real production wiring substitutes a `ChannelSink`
-/// once per-session TCP writers exist; for the smoke binary we
-/// keep the hot path alloc-free and surface a periodic counter.
-#[derive(Default)]
-struct CountingSink {
-    count: u64,
-}
-
-impl OutboundSink for CountingSink {
-    fn emit(&mut self, _msg: Outbound) {
-        self.count = self.count.wrapping_add(1);
-    }
-}
+const OUTBOUND_BROADCAST_CAPACITY: usize = 1024;
+const INBOUND_CHANNEL_CAPACITY: usize = 8192;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> std::io::Result<()> {
@@ -51,7 +46,7 @@ async fn main() -> std::io::Result<()> {
     // typed `Inbound`. The engine is sync. We bridge with a sync
     // mpsc channel so the engine thread can `recv()` blocking.
     let (sync_tx, sync_rx) = mpsc::channel::<Inbound>();
-    let (tokio_tx, mut tokio_rx) = tmpsc::channel::<Inbound>(8192);
+    let (tokio_tx, mut tokio_rx) = tmpsc::channel::<Inbound>(INBOUND_CHANNEL_CAPACITY);
 
     // Forwarder task: read from tokio mpsc, push into sync mpsc.
     tokio::spawn(async move {
@@ -63,32 +58,34 @@ async fn main() -> std::io::Result<()> {
         }
     });
 
+    // Outbound sink shared between engine (producer) and listener
+    // (subscriber factory). Both clones share the same broadcast.
+    let sink = ChannelSink::new(OUTBOUND_BROADCAST_CAPACITY);
+    let listener_sink = Arc::new(sink.clone());
+
     // Engine thread.
     thread::Builder::new()
         .name("engine".into())
-        .spawn(move || engine_loop(sync_rx))
+        .spawn(move || engine_loop(sync_rx, sink))
         .expect("engine thread spawn");
 
     // Listener loop. Returns on listener error.
-    if let Err(e) = run(&addr, tokio_tx).await {
+    if let Err(e) = run(&addr, tokio_tx, listener_sink).await {
         eprintln!("engine: listener error: {e}");
         return Err(e);
     }
     Ok(())
 }
 
-fn engine_loop(rx: mpsc::Receiver<Inbound>) {
-    let mut engine = Engine::new(
-        WallClock,
-        CounterIdGenerator::new(),
-        CountingSink::default(),
-    );
+fn engine_loop(rx: mpsc::Receiver<Inbound>, sink: ChannelSink) {
+    let mut engine = Engine::new(WallClock, CounterIdGenerator::new(), sink);
+    let mut count: u64 = 0;
     let mut last_log: u64 = 0;
     while let Ok(msg) = rx.recv() {
         engine.step(msg);
-        let count = engine.sink_mut().count;
+        count = count.wrapping_add(1);
         if count.is_multiple_of(10_000) && count != last_log {
-            eprintln!("engine: outbound count = {count}");
+            eprintln!("engine: processed {count} inbound commands");
             last_log = count;
         }
     }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -16,6 +16,6 @@ pub mod recorder;
 /// Outbound channel sink — engine emits, async writer drains.
 pub mod sink;
 
-pub use listener::{DEFAULT_READ_BUFFER, handle_connection, run};
+pub use listener::{DEFAULT_READ_BUFFER, OutboundSubscriber, handle_connection, run};
 pub use recorder::{RECV_TS_BYTES, Record, Recorder, read_records};
 pub use sink::ChannelSink;

--- a/crates/gateway/src/listener.rs
+++ b/crates/gateway/src/listener.rs
@@ -26,10 +26,10 @@
 use std::io;
 use std::net::SocketAddr;
 
-use bytes::BytesMut;
-use tokio::io::AsyncReadExt;
+use bytes::{Bytes, BytesMut};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, info, warn};
 
 use wire::WireError;
@@ -98,7 +98,34 @@ fn try_decode(buf: &[u8]) -> DecodeStep {
 /// Surfaces the underlying [`std::io::Error`] from `bind` /
 /// `accept` calls. Per-connection failures are logged and do not
 /// stop the accept loop.
-pub async fn run(addr: &str, tx: mpsc::Sender<Inbound>) -> io::Result<()> {
+/// Trait for the per-connection outbound subscription source.
+/// `crate::sink::ChannelSink` implements this; tests pass a mock to
+/// drive `handle_connection` without standing up a full engine.
+pub trait OutboundSubscriber: Send + Sync + 'static {
+    /// Open a fresh broadcast subscription. Each connection receives
+    /// every outbound frame emitted *after* its subscribe() call —
+    /// CLAUDE.md's "no replay history" pattern; clients reconcile via
+    /// `SnapshotRequest` after connect.
+    fn subscribe(&self) -> broadcast::Receiver<Bytes>;
+}
+
+/// Bind a TCP listener and serve every accepted connection through
+/// `handle_connection`. Each connection gets its own broadcast
+/// `Receiver<Bytes>` from `sink.subscribe()` so it sees every
+/// outbound frame the engine emits *after* its connect.
+///
+/// # Errors
+/// Surfaces the underlying [`std::io::Error`] from `bind` /
+/// `accept` calls. Per-connection failures are logged and do not
+/// stop the accept loop.
+pub async fn run<S>(
+    addr: &str,
+    tx: mpsc::Sender<Inbound>,
+    sink: std::sync::Arc<S>,
+) -> io::Result<()>
+where
+    S: OutboundSubscriber,
+{
     let listener = TcpListener::bind(addr).await?;
     let local = listener.local_addr()?;
     info!(addr = %local, "gateway listener bound");
@@ -106,22 +133,54 @@ pub async fn run(addr: &str, tx: mpsc::Sender<Inbound>) -> io::Result<()> {
         let (sock, peer) = listener.accept().await?;
         debug!(peer = %peer, "gateway accepted connection");
         let tx_clone = tx.clone();
+        let rx = sink.subscribe();
         tokio::spawn(async move {
-            handle_connection(sock, peer, tx_clone, DEFAULT_READ_BUFFER).await;
+            handle_connection(sock, peer, tx_clone, rx, DEFAULT_READ_BUFFER).await;
         });
     }
 }
 
 /// Drive one accepted connection until disconnect / channel full /
-/// malformed payload. Public so tests can drive it without binding
-/// a real TCP listener.
+/// malformed payload. Spawns a sub-task that pumps outbound frames
+/// from `out_rx` to the socket's write half. Public so tests can
+/// drive it without binding a real TCP listener.
 pub async fn handle_connection(
     sock: TcpStream,
     peer: SocketAddr,
     tx: mpsc::Sender<Inbound>,
+    out_rx: broadcast::Receiver<Bytes>,
     buffer_capacity: usize,
 ) {
-    let (mut read_half, _write_half) = sock.into_split();
+    let (mut read_half, mut write_half) = sock.into_split();
+
+    // Outbound writer: pumps every frame the engine broadcasts onto
+    // this session's TCP write half. A subscriber that falls behind
+    // by more than the broadcast capacity (`Lagged(_)`) is dropped —
+    // the client must reconnect and re-subscribe to recover. The
+    // engine never blocks on a slow consumer.
+    let mut out_rx = out_rx;
+    let writer_peer = peer;
+    let writer_task = tokio::spawn(async move {
+        loop {
+            match out_rx.recv().await {
+                Ok(frame) => {
+                    if let Err(err) = write_half.write_all(&frame).await {
+                        warn!(peer = %writer_peer, error = %err, "gateway: outbound write error, closing");
+                        return;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(peer = %writer_peer, skipped, "gateway: outbound subscriber lagged, closing");
+                    return;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    debug!(peer = %writer_peer, "gateway: outbound channel closed");
+                    return;
+                }
+            }
+        }
+    });
+
     let mut buf = BytesMut::with_capacity(buffer_capacity);
     loop {
         // Drain whatever already-buffered frames we can before
@@ -133,17 +192,20 @@ pub async fn handle_connection(
                     buf.advance_consume(total);
                     if let Err(send_err) = tx.try_send(msg) {
                         warn!(peer = %peer, error = %send_err, "gateway: matching ring full, closing connection");
+                        writer_task.abort();
                         return;
                     }
                 }
                 DecodeStep::Malformed { err, total } => {
                     warn!(peer = %peer, error = %err, "gateway: malformed inbound frame, closing connection");
                     let _ = total;
+                    writer_task.abort();
                     return;
                 }
                 DecodeStep::Skipped { byte, total } => {
                     warn!(peer = %peer, byte, "gateway: unknown / outbound kind on inbound stream, closing");
                     let _ = total;
+                    writer_task.abort();
                     return;
                 }
                 DecodeStep::NeedMore => break,
@@ -152,11 +214,13 @@ pub async fn handle_connection(
         match read_half.read_buf(&mut buf).await {
             Ok(0) => {
                 debug!(peer = %peer, "gateway: peer closed connection");
+                writer_task.abort();
                 return;
             }
             Ok(_n) => {}
             Err(err) => {
                 warn!(peer = %peer, error = %err, "gateway: read error, closing");
+                writer_task.abort();
                 return;
             }
         }
@@ -216,7 +280,8 @@ mod tests {
         // Background accept loop — processes one connection.
         let server = tokio::spawn(async move {
             let (sock, peer) = listener.accept().await.expect("accept");
-            handle_connection(sock, peer, tx, DEFAULT_READ_BUFFER).await;
+            let (_outbound_tx, outbound_rx) = broadcast::channel::<Bytes>(16);
+            handle_connection(sock, peer, tx, outbound_rx, DEFAULT_READ_BUFFER).await;
         });
 
         let mut client = TcpStream::connect(addr).await.expect("connect");
@@ -246,7 +311,8 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (sock, peer) = listener.accept().await.expect("accept");
-            handle_connection(sock, peer, tx, DEFAULT_READ_BUFFER).await;
+            let (_outbound_tx, outbound_rx) = broadcast::channel::<Bytes>(16);
+            handle_connection(sock, peer, tx, outbound_rx, DEFAULT_READ_BUFFER).await;
         });
 
         let mut client = TcpStream::connect(addr).await.expect("connect");
@@ -274,7 +340,8 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (sock, peer) = listener.accept().await.expect("accept");
-            handle_connection(sock, peer, tx, DEFAULT_READ_BUFFER).await;
+            let (_outbound_tx, outbound_rx) = broadcast::channel::<Bytes>(16);
+            handle_connection(sock, peer, tx, outbound_rx, DEFAULT_READ_BUFFER).await;
         });
 
         // Build a syntactically valid frame whose `kind` is NewOrder
@@ -294,5 +361,57 @@ mod tests {
             Err(_) => panic!("server did not close on malformed frame"),
         }
         server.await.expect("server done");
+    }
+
+    #[tokio::test]
+    async fn test_listener_pumps_outbound_frames_to_client() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (tx, _rx) = mpsc::channel::<Inbound>(8);
+        let (outbound_tx, _) = broadcast::channel::<Bytes>(16);
+        let outbound_tx_clone = outbound_tx.clone();
+
+        let server = tokio::spawn(async move {
+            let (sock, peer) = listener.accept().await.expect("accept");
+            let outbound_rx = outbound_tx_clone.subscribe();
+            handle_connection(sock, peer, tx, outbound_rx, DEFAULT_READ_BUFFER).await;
+        });
+
+        let mut client = TcpStream::connect(addr).await.expect("connect");
+        // Give the server a moment to subscribe before we publish.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Push two arbitrary framed payloads onto the broadcast.
+        let payload_a = Bytes::from_static(&[
+            0x01, 0x00, 0x00, 0x00, // len = 1
+            0x65, // ExecReport kind (any kind works for the byte echo test)
+        ]);
+        let payload_b = Bytes::from_static(&[
+            0x02, 0x00, 0x00, 0x00, // len = 2
+            0x66, // TradePrint kind
+            0xAB, // 1 byte of payload
+        ]);
+        outbound_tx.send(payload_a.clone()).expect("send");
+        outbound_tx.send(payload_b.clone()).expect("send");
+
+        // Read the bytes back.
+        let mut received = vec![0u8; payload_a.len() + payload_b.len()];
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            client.read_exact(&mut received),
+        )
+        .await
+        .expect("read timeout")
+        .expect("read");
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&payload_a);
+        expected.extend_from_slice(&payload_b);
+        assert_eq!(received, expected);
+
+        // Close the client to terminate the server cleanly.
+        drop(client);
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), server).await;
     }
 }

--- a/crates/gateway/src/sink.rs
+++ b/crates/gateway/src/sink.rs
@@ -18,9 +18,18 @@ use tokio::sync::broadcast;
 use tracing::warn;
 use wire::outbound::Outbound;
 
+use crate::listener::OutboundSubscriber;
+
 /// Channel-backed [`OutboundSink`]. The engine thread holds the
 /// `Sender`; tokio writer tasks `subscribe()` to receive framed
 /// bytes ready for TCP `write_all`.
+///
+/// `Clone` is cheap — the inner `broadcast::Sender` is itself
+/// `Clone`, and every clone broadcasts onto the same underlying
+/// channel. The engine binary clones the sink into the listener
+/// (Arc-wrapped, subscribe-only) so producer and subscribers share
+/// one stream.
+#[derive(Clone)]
 pub struct ChannelSink {
     tx: broadcast::Sender<Bytes>,
 }
@@ -47,6 +56,12 @@ impl ChannelSink {
     #[must_use]
     pub fn receiver_count(&self) -> usize {
         self.tx.receiver_count()
+    }
+}
+
+impl OutboundSubscriber for ChannelSink {
+    fn subscribe(&self) -> broadcast::Receiver<Bytes> {
+        ChannelSink::subscribe(self)
     }
 }
 

--- a/crates/gateway/tests/end_to_end.rs
+++ b/crates/gateway/tests/end_to_end.rs
@@ -1,0 +1,141 @@
+//! End-to-end test: TCP client → gateway → engine → ChannelSink →
+//! gateway writer → TCP client. Verifies #43's contract: a
+//! connected client can submit a `NewOrder` and read back the
+//! corresponding `ExecReport{Accepted}` + `BookUpdateTop` on the
+//! same socket.
+
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use domain::{AccountId, ClientTs, OrderId, OrderType, Price, Qty, Side, Tif};
+use engine::{CounterIdGenerator, Engine, StubClock};
+use gateway::{ChannelSink, handle_connection};
+use marketdata::encoder;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc as tmpsc;
+use wire::framing::{Frame, MessageKind};
+use wire::inbound::{Inbound, NewOrder, new_order};
+use wire::outbound::Outbound;
+
+#[tokio::test]
+async fn end_to_end_client_round_trip() {
+    // Bind a fresh listener on an ephemeral port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let (sync_tx, sync_rx) = mpsc::channel::<Inbound>();
+    let (tokio_tx, mut tokio_rx) = tmpsc::channel::<Inbound>(64);
+
+    // Forwarder: tokio mpsc → sync mpsc.
+    tokio::spawn(async move {
+        while let Some(msg) = tokio_rx.recv().await {
+            if sync_tx.send(msg).is_err() {
+                return;
+            }
+        }
+    });
+
+    // Outbound sink: shared between engine (producer) and listener
+    // (subscribe-only via Arc).
+    let sink = ChannelSink::new(64);
+    let listener_sink = Arc::new(sink.clone());
+
+    // Engine thread.
+    thread::Builder::new()
+        .name("engine".into())
+        .spawn(move || {
+            let mut engine =
+                Engine::new(StubClock::new(1_000_000), CounterIdGenerator::new(), sink);
+            while let Ok(msg) = sync_rx.recv() {
+                engine.step(msg);
+            }
+        })
+        .expect("engine thread");
+
+    // Accept loop driven directly so we own lifetime cleanly and
+    // avoid double-binding the listener.
+    tokio::spawn(async move {
+        loop {
+            let (sock, peer) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let rx = listener_sink.subscribe();
+            let tx_clone = tokio_tx.clone();
+            tokio::spawn(async move {
+                handle_connection(sock, peer, tx_clone, rx, gateway::DEFAULT_READ_BUFFER).await;
+            });
+        }
+    });
+
+    // Give the listener a moment to bind & subscribe.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Client connects.
+    let mut client = TcpStream::connect(addr).await.expect("connect");
+    // The listener subscribes per-connection, but the subscribe
+    // happens after `accept` returns. Sleep briefly so the
+    // subscribe registers before our first send triggers an emit.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Send a NewOrder framed.
+    let msg = NewOrder {
+        client_ts: ClientTs::new(0),
+        order_id: OrderId::new(42).expect("ok"),
+        account_id: AccountId::new(7).expect("ok"),
+        side: Side::Bid,
+        order_type: OrderType::Limit,
+        tif: Tif::Gtc,
+        price: Some(Price::new(100).expect("ok")),
+        qty: Qty::new(5).expect("ok"),
+    };
+    let mut payload = Vec::new();
+    new_order::encode(&msg, &mut payload);
+    let mut frame = Vec::new();
+    Frame::write(MessageKind::NewOrder, &payload, &mut frame).expect("frame");
+    client.write_all(&frame).await.expect("write");
+
+    // Read at least one ExecReport + one BookUpdateTop. Reading
+    // until we have decoded both is the cleanest way to span the
+    // fact that the engine may emit more frames over time.
+    let mut buf: Vec<u8> = Vec::new();
+    let mut got_exec = false;
+    let mut got_top = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while tokio::time::Instant::now() < deadline && !(got_exec && got_top) {
+        let mut tmp = [0u8; 256];
+        let n = tokio::time::timeout(Duration::from_millis(500), client.read(&mut tmp))
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .unwrap_or(0);
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        // Drain whatever frames we can.
+        while let Ok((decoded, total)) = encoder::decode(&buf) {
+            buf.drain(..total);
+            match decoded {
+                Outbound::ExecReport(r) => {
+                    assert_eq!(r.order_id, OrderId::new(42).expect("ok"));
+                    assert_eq!(r.account_id, AccountId::new(7).expect("ok"));
+                    got_exec = true;
+                }
+                Outbound::BookUpdateTop(_) => {
+                    got_top = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(got_exec, "expected ExecReport on the same TCP connection");
+    assert!(got_top, "expected BookUpdateTop on the same TCP connection");
+
+    drop(client);
+}


### PR DESCRIPTION
## Summary
- New `OutboundSubscriber` trait + modified `gateway::run<S>` so the listener pulls a per-connection `broadcast::Receiver<Bytes>` from a generic sink. Tests pass a mock; production passes `Arc<ChannelSink>`.
- `handle_connection` spawns a per-session writer task that pumps `Bytes` from the broadcast onto the socket's write half. Zero per-frame allocation on the receive side.
- Engine binary replaces `CountingSink` with a `ChannelSink` shared between engine thread (producer) and listener (subscribe-only via Arc).
- New `crates/gateway/tests/end_to_end.rs` drives the full path: TCP client → gateway → engine → ChannelSink → gateway writer → TCP client. Asserts `ExecReport{Accepted}` + `BookUpdateTop` arrive on the same socket after a `NewOrder`.

Closes #43.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 230 / 230 pass.
- [x] `cargo build --release`
- [x] `determinism-auditor`: Replay safe / Commit safe both yes.
- [x] `hotpath-reviewer`: OK to commit (P2 follow-up: pool encoder Vec inside `ChannelSink::emit`).