### PR TITLE
feat(engine): optional CPU pinning of matching thread (#47)

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -23,7 +23,7 @@ discipline.
 | RNG | Seeded LCG inside the bench (no `rand::*`, deterministic) |
 | Sink | `engine::VecSink` with `events.clear()` per op (drains, never mutates external state) |
 | Clock | `BenchClock` — synthetic monotonic, one tick per `now()` call |
-| CPU pinning | None (default macOS scheduler); pinning to the perf cores is future work |
+| CPU pinning | Optional via `pinned-engine` feature + `--engine-core <N>`. Default off — Linux is the supported target; macOS treats the affinity hint as a soft QoS bias. |
 | Coordinated-omission correction | **None at the bench level**. The bench drives synchronous `step()` calls in a tight loop; there is no arrival-rate target, so the classical CO failure mode (a slow op delays the next request and hides the slow op from the histogram) does not apply. Histogram values are raw `t_end - t_start` per op. When this bench grows a closed-loop driver (issue 17 follow-up), `Histogram::record_correct(value, expected_interval)` will replace `record(value)`. |
 
 The driver is `criterion::iter_batched` with `BatchSize::SmallInput`
@@ -68,6 +68,38 @@ across the captured-budget run is already in line with the
 microstructure cost model (matching is dominated by the
 `snapshot_orders()` allocation per level entry, which is the next
 target — see "Where the tail comes from" below).
+
+## CPU pinning + NUMA placement
+
+The engine binary supports CPU pinning behind a feature flag —
+recommended on Linux for production runs and bench laps where p99.99 /
+max are interesting.
+
+```bash
+cargo run --release --features pinned-engine --bin engine -- 0.0.0.0:9000 --engine-core 4
+```
+
+What pinning actually does:
+
+- Linux: `core_affinity::set_for_current` calls `sched_setaffinity(2)`
+  with a single-CPU mask. The matching thread stops migrating across
+  cores. Combined with `taskset` / `cpuset` cgroups isolating the
+  chosen core from other workloads, the p99.99 tail collapses
+  toward p99 because OS scheduler preemption disappears.
+- macOS: the same `core_affinity` call maps to a QoS hint
+  (`pthread_set_qos_class_self_np`-style). Effect is real but
+  smaller than on Linux — reproducible numbers there require a
+  Linux box.
+
+NUMA placement is intentionally out of scope for v1 (single-symbol,
+single-thread engine doesn't have a memory-locality story to tell
+yet). When the SPMC outbound bipartite split lands per the README's
+"honest limitation" section, the producer / consumer threads should
+co-locate on the same NUMA node — that's a follow-up issue.
+
+Without the `pinned-engine` feature, `--engine-core` is parsed but
+ignored with a warning. The unpinned path is what the captured
+numbers in this document reflect.
 
 ## Sustained throughput
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ zerocopy          = { version = "0.8", features = ["derive"] }
 uuid              = "1"
 tempfile          = "3"
 dhat              = "0.3"
+core_affinity     = "0.8"
 
 [profile.release]
 opt-level     = 3

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,13 @@ ADDR ?= 0.0.0.0:9000
 run-addr:
 	cargo run --release --bin engine -- $(ADDR)
 
+# Run the engine binary with the matching thread pinned to a core.
+# Usage: make run-pinned CORE=4
+CORE ?= 0
+.PHONY: run-pinned
+run-pinned:
+	cargo run --release --features pinned-engine --bin engine -- $(ADDR) --engine-core $(CORE)
+
 # Replay the committed inbound fixture and diff against the golden.
 # Silent output = byte-identical match.
 .PHONY: replay

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -22,6 +22,7 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync"] }
 hdrhistogram.workspace = true
 dhat = { workspace = true, optional = true }
+core_affinity = { workspace = true, optional = true }
 
 [features]
 # Enables `dhat-rs` allocation profiling on the smoke bench. Wires
@@ -29,6 +30,12 @@ dhat = { workspace = true, optional = true }
 # `cargo run --release --features hotpath-dhat --bin dhat_bench`
 # runs.
 hotpath-dhat = ["dep:dhat"]
+# Enables `core_affinity`-based CPU pinning of the engine thread.
+# When enabled the engine binary accepts `--engine-core <N>` and
+# pins the matching thread to that physical core via
+# `core_affinity::set_for_current`. Linux is best-supported;
+# macOS treats the call as a soft hint via QoS.
+pinned-engine = ["dep:core_affinity"]
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/engine/src/bin/engine.rs
+++ b/crates/engine/src/bin/engine.rs
@@ -5,13 +5,23 @@
 //! ## CLI
 //!
 //! ```text
-//! engine [bind_addr]
+//! engine [bind_addr] [--engine-core <N>]
 //! ```
 //!
 //! Default bind address `0.0.0.0:9000`. Connected clients can
 //! submit framed inbound messages and read framed outbound bytes
-//! (`ExecReport` / `TradePrint` / `BookUpdateTop` / `SnapshotResponse`)
-//! on the same TCP connection.
+//! (`ExecReport` / `TradePrint` / `BookUpdateTop` /
+//! `BookUpdateL2Delta` / `SnapshotResponse`) on the same TCP
+//! connection.
+//!
+//! `--engine-core <N>` pins the matching thread to physical core
+//! `N` via `core_affinity::set_for_current`. Requires the
+//! `pinned-engine` feature flag at compile time. Linux is the
+//! best-supported target — pinning sharply reduces p99.99 / max
+//! tail latency under load by removing scheduler preemption.
+//! macOS treats the affinity hint as a soft QoS bias; the
+//! observable delta is smaller. Without the flag (or without the
+//! feature), the engine thread runs on the OS-default scheduler.
 //!
 //! ## Backpressure
 //!
@@ -39,8 +49,17 @@ const INBOUND_CHANNEL_CAPACITY: usize = 8192;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let addr = args.get(1).cloned().unwrap_or_else(|| DEFAULT_ADDR.into());
+    let addr = args
+        .iter()
+        .skip(1)
+        .find(|a| !a.starts_with("--"))
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_ADDR.into());
+    let engine_core = parse_engine_core(&args);
     eprintln!("engine: binding gateway listener on {addr}");
+    if let Some(core) = engine_core {
+        eprintln!("engine: requested CPU pinning to core {core}");
+    }
 
     // Async → sync bridge: the gateway runs on tokio and produces
     // typed `Inbound`. The engine is sync. We bridge with a sync
@@ -66,7 +85,10 @@ async fn main() -> std::io::Result<()> {
     // Engine thread.
     thread::Builder::new()
         .name("engine".into())
-        .spawn(move || engine_loop(sync_rx, sink))
+        .spawn(move || {
+            pin_to_core(engine_core);
+            engine_loop(sync_rx, sink);
+        })
         .expect("engine thread spawn");
 
     // Listener loop. Returns on listener error.
@@ -75,6 +97,55 @@ async fn main() -> std::io::Result<()> {
         return Err(e);
     }
     Ok(())
+}
+
+/// Parse `--engine-core <N>` from `args`. Returns `None` when the
+/// flag is absent or the value is malformed (silently — pinning is
+/// a soft optimisation; an invalid argument should not fail boot).
+fn parse_engine_core(args: &[String]) -> Option<usize> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--engine-core" {
+            return iter.next().and_then(|v| v.parse::<usize>().ok());
+        }
+    }
+    None
+}
+
+#[cfg(feature = "pinned-engine")]
+fn pin_to_core(core: Option<usize>) {
+    let Some(core_idx) = core else {
+        return;
+    };
+    match core_affinity::get_core_ids() {
+        Some(ids) => match ids.get(core_idx) {
+            Some(id) => {
+                if core_affinity::set_for_current(*id) {
+                    eprintln!("engine: pinned thread to core {core_idx}");
+                } else {
+                    eprintln!("engine: pin to core {core_idx} failed (continuing unpinned)");
+                }
+            }
+            None => {
+                eprintln!(
+                    "engine: requested core {core_idx} out of range (have {} cores)",
+                    ids.len()
+                );
+            }
+        },
+        None => {
+            eprintln!("engine: core_affinity::get_core_ids() returned None — cannot pin");
+        }
+    }
+}
+
+#[cfg(not(feature = "pinned-engine"))]
+fn pin_to_core(core: Option<usize>) {
+    if core.is_some() {
+        eprintln!(
+            "engine: --engine-core requested but binary not built with `--features pinned-engine`"
+        );
+    }
 }
 
 fn engine_loop(rx: mpsc::Receiver<Inbound>, sink: ChannelSink) {


### PR DESCRIPTION
## Summary
- New `pinned-engine` feature flag + `core_affinity` workspace dep (optional).
- Engine binary accepts `--engine-core <N>`. With the feature enabled, pins the matching thread via `core_affinity::set_for_current`. Without the feature, soft-warns and runs unpinned.
- BENCH.md gains a "CPU pinning + NUMA placement" section explaining what pinning actually does on Linux vs macOS, and defers NUMA placement to the SPMC bipartite outbound follow-up.
- Makefile: `make run-pinned CORE=4`.

Closes #47.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default features).
- [x] `cargo clippy --all-targets --features pinned-engine -- -D warnings`.
- [x] `cargo nextest run` — 233 / 233 pass.
- [x] `cargo build --release --bin engine` (unpinned default).
- [x] `cargo build --release --features pinned-engine --bin engine` (pinned variant).