### PR TITLE
bench(engine): closed-loop CO-corrected bench (#48)

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -24,7 +24,7 @@ discipline.
 | Sink | `engine::VecSink` with `events.clear()` per op (drains, never mutates external state) |
 | Clock | `BenchClock` — synthetic monotonic, one tick per `now()` call |
 | CPU pinning | Optional via `pinned-engine` feature + `--engine-core <N>`. Default off — Linux is the supported target; macOS treats the affinity hint as a soft QoS bias. |
-| Coordinated-omission correction | **None at the bench level**. The bench drives synchronous `step()` calls in a tight loop; there is no arrival-rate target, so the classical CO failure mode (a slow op delays the next request and hides the slow op from the histogram) does not apply. Histogram values are raw `t_end - t_start` per op. When this bench grows a closed-loop driver (issue 17 follow-up), `Histogram::record_correct(value, expected_interval)` will replace `record(value)`. |
+| Coordinated-omission correction | None on the open-loop `add_cancel_mix` Criterion bench (no arrival-rate target). A separate `co_bench` binary runs a **closed-loop** driver at a configurable target rate and applies `Histogram::record_correct(value, expected_interval)`. See "Closed-loop CO-corrected" section below. |
 
 The driver is `criterion::iter_batched` with `BatchSize::SmallInput`
 to keep the per-iter setup cost (`Engine::new`) outside the
@@ -68,6 +68,67 @@ across the captured-budget run is already in line with the
 microstructure cost model (matching is dominated by the
 `snapshot_orders()` allocation per level entry, which is the next
 target — see "Where the tail comes from" below).
+
+## Closed-loop CO-corrected
+
+The Criterion `add_cancel_mix` bench is open-loop: a tight `for` loop
+calls `engine.step()` synchronously and records `t_end - t_start`.
+That measurement style understates tail latency under realistic
+offered load — when `step()` runs slow, the next "request" is
+delayed and the slow op is hidden from the histogram.
+
+`crates/engine/src/bin/co_bench.rs` runs a closed-loop driver at a
+configurable target arrival rate. Each op is scheduled at
+`bench_start + i * interval`; before issuing, the driver
+busy-waits (`spin_loop`) until `Instant::now() >= scheduled`. The
+recorded value is `scheduled.elapsed()` — i.e., the latency the
+producer would observe from "I would have delivered this at time T"
+to "engine returned." `Histogram::record_correct(value,
+expected_interval)` synthesises additional records for any op
+where `value > interval`, backfilling the missed intervals.
+
+### Run
+
+```bash
+# Default 200k ops/sec target rate, 1M ops measurement.
+cargo run --release --bin co_bench
+
+# Custom rate via env var.
+TARGET_OPS_PER_SEC=100000 cargo run --release --bin co_bench
+```
+
+### Captured numbers (Apple M4 Max, release build, 100k ops/sec target)
+
+| Metric | Value |
+|--------|------:|
+| Target rate | 100,000 ops/sec |
+| Interval | 10,000 ns |
+| Warmup | 50,000 ops |
+| Measurement | 1,000,000 ops |
+| Wall-clock | 9,999 ms |
+| p50 | 26,543 ns |
+| p99 | 813,055 ns |
+| p99.9 | 1,209,343 ns |
+| p99.99 | 1,577,983 ns |
+| max | 1,765,375 ns |
+
+### Comparison to open-loop
+
+Open-loop p99.9 from the Criterion bench is ~210 µs; CO-corrected
+p99.9 at 100k ops/sec is ~1.21 ms, reflecting the additional
+latency a real producer offering load at that rate would have
+observed. The deltas are dominated by:
+
+- Spin-loop overshoot on macOS — `Instant::now()` is precise but
+  the spin path itself has scheduler-driven jitter at sub-µs scale.
+- Engine `step()` cost variance (the same `snapshot_orders()`
+  allocation that drives the open-loop tail still applies).
+
+On a Linux box with `--engine-core` pinning + `taskset` cgroup
+isolation the CO-corrected p50 should collapse toward the open-
+loop p50 (the spin path is ns-precise without scheduler jitter).
+Capturing those numbers is a follow-up — the methodology and the
+binary are in place.
 
 ## CPU pinning + NUMA placement
 

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,13 @@ dhat:
 throughput:
 	cargo run --release --bin throughput_bench
 
+# Closed-loop bench with coordinated-omission correction.
+# Usage: make co-bench RATE=100000 (default 200k ops/sec).
+RATE ?= 200000
+.PHONY: co-bench
+co-bench:
+	TARGET_OPS_PER_SEC=$(RATE) cargo run --release --bin co_bench
+
 # Full bench (Criterion, default budget). Allow ~18 min wall-clock.
 .PHONY: bench-full
 bench-full:

--- a/crates/engine/src/bin/co_bench.rs
+++ b/crates/engine/src/bin/co_bench.rs
@@ -1,0 +1,238 @@
+//! `co_bench` — closed-loop bench with coordinated-omission correction.
+//!
+//! Drives `add_cancel_mix` at a fixed target arrival rate. Each op
+//! is scheduled at `start + i * interval`; the actual latency
+//! recorded is `t_end - scheduled_start`. When the engine takes
+//! longer than `interval`, subsequent ops are delayed: classical
+//! coordinated omission. `Histogram::record_correct(value,
+//! expected_interval)` backfills the histogram for the missed
+//! intervals so the resulting percentiles reflect what a real
+//! producer offering load at that rate would have observed.
+//!
+//! ## Run
+//!
+//! ```bash
+//! # Default 200k ops/sec target rate, 1M ops measurement.
+//! cargo run --release --bin co_bench
+//!
+//! # Custom rate via env var.
+//! TARGET_OPS_PER_SEC=500000 cargo run --release --bin co_bench
+//! ```
+//!
+//! Compare against the open-loop number printed by `smoke_bench`
+//! at the same hardware.
+
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+use domain::{AccountId, ClientTs, Clock, OrderId, OrderType, Price, Qty, RecvTs, Side, Tif};
+use engine::{CounterIdGenerator, Engine, VecSink};
+use hdrhistogram::Histogram;
+use wire::inbound::{CancelOrder, Inbound, NewOrder};
+
+const N_WARMUP: u64 = 50_000;
+const N_MEASURE: u64 = 1_000_000;
+const DEFAULT_TARGET_OPS_PER_SEC: u64 = 200_000;
+const ACCOUNT_COUNT: u64 = 8;
+const PRICE_LOW: i64 = 90;
+const PRICE_HIGH: i64 = 110;
+
+struct BenchClock {
+    next: Cell<i64>,
+}
+impl BenchClock {
+    fn new() -> Self {
+        Self { next: Cell::new(1) }
+    }
+}
+impl Clock for BenchClock {
+    fn now(&self) -> RecvTs {
+        let v = self.next.get();
+        self.next.set(v + 1);
+        RecvTs::new(v)
+    }
+}
+
+struct Lcg(u64);
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        self.0
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Op {
+    Add {
+        id: u64,
+        account: u32,
+        side: Side,
+        price: i64,
+        qty: u64,
+    },
+    Cancel {
+        id: u64,
+        account: u32,
+    },
+    Aggressive {
+        id: u64,
+        account: u32,
+        side: Side,
+        price: i64,
+        qty: u64,
+    },
+}
+
+fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
+    let mut rng = Lcg::new(seed);
+    let mut ops = Vec::with_capacity(n as usize);
+    let mut next_id: u64 = 1;
+    let mut active_ids: Vec<u64> = Vec::new();
+    for _ in 0..n {
+        let r = rng.next() % 100;
+        let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
+        let side = if rng.next().is_multiple_of(2) {
+            Side::Bid
+        } else {
+            Side::Ask
+        };
+        let qty = (rng.next() % 9) + 1;
+        if r < 20 && !active_ids.is_empty() {
+            let idx = (rng.next() as usize) % active_ids.len();
+            let id = active_ids.swap_remove(idx);
+            ops.push(Op::Cancel { id, account });
+        } else if r < 30 {
+            let price = PRICE_LOW + (rng.next() as i64) % (PRICE_HIGH - PRICE_LOW + 1);
+            ops.push(Op::Aggressive {
+                id: next_id,
+                account,
+                side,
+                price,
+                qty,
+            });
+            next_id += 1;
+        } else {
+            let safe_price = match side {
+                Side::Bid => PRICE_LOW,
+                Side::Ask => PRICE_HIGH,
+            };
+            ops.push(Op::Add {
+                id: next_id,
+                account,
+                side,
+                price: safe_price,
+                qty,
+            });
+            active_ids.push(next_id);
+            next_id += 1;
+        }
+    }
+    ops
+}
+
+fn op_to_inbound(op: Op) -> Inbound {
+    match op {
+        Op::Add {
+            id,
+            account,
+            side,
+            price,
+            qty,
+        }
+        | Op::Aggressive {
+            id,
+            account,
+            side,
+            price,
+            qty,
+        } => Inbound::NewOrder(NewOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(id).expect("ok"),
+            account_id: AccountId::new(account).expect("ok"),
+            side,
+            order_type: OrderType::Limit,
+            tif: Tif::Gtc,
+            price: Some(Price::new(price).expect("ok")),
+            qty: Qty::new(qty).expect("ok"),
+        }),
+        Op::Cancel { id, account } => Inbound::CancelOrder(CancelOrder {
+            client_ts: ClientTs::new(0),
+            order_id: OrderId::new(id).expect("ok"),
+            account_id: AccountId::new(account).expect("ok"),
+        }),
+    }
+}
+
+fn main() {
+    let target_rate: u64 = std::env::var("TARGET_OPS_PER_SEC")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TARGET_OPS_PER_SEC);
+    let interval_ns: u64 = 1_000_000_000 / target_rate;
+    let interval = Duration::from_nanos(interval_ns);
+
+    let warmup_ops = generate_ops(N_WARMUP, 0xdeadbeef);
+    let measure_ops = generate_ops(N_MEASURE, 0xc0ffee);
+
+    let mut engine = Engine::new(BenchClock::new(), CounterIdGenerator::new(), VecSink::new());
+
+    // Open-loop warmup just to warm caches; closed-loop measurement
+    // applies after.
+    for op in &warmup_ops {
+        engine.step(op_to_inbound(*op));
+        engine.sink_mut().events.clear();
+    }
+
+    let mut hist =
+        Histogram::<u64>::new_with_bounds(1, 30_000_000_000, 3).expect("histogram bounds valid");
+
+    let bench_start = Instant::now();
+    for (i, op) in measure_ops.iter().enumerate() {
+        let scheduled = bench_start + interval * (i as u32);
+        // Busy-wait spin until the scheduled time. `thread::sleep`
+        // on macOS / Linux has ~100 µs granularity which dominates
+        // the latency budget at high target rates. Spin keeps the
+        // CPU hot and gives ns-precision scheduling. Acceptable
+        // for a bench harness; production schedulers would use a
+        // hybrid sleep + spin pattern.
+        while Instant::now() < scheduled {
+            std::hint::spin_loop();
+        }
+        let inbound = op_to_inbound(*op);
+        let t0 = Instant::now();
+        engine.step(inbound);
+        let step_ns = t0.elapsed().as_nanos() as u64;
+        // Latency seen from the producer's perspective: time
+        // between when the message would have arrived and when it
+        // finished being processed. Captures coordinated omission
+        // — if `step_ns > interval_ns`, the next op was already
+        // late at delivery.
+        let scheduled_latency_ns = scheduled.elapsed().as_nanos() as u64;
+        let _ = hist.record_correct(scheduled_latency_ns.max(1), interval_ns);
+        engine.sink_mut().events.clear();
+        // Suppress unused: kept for diagnostic purposes if a
+        // future consumer wants step-only vs scheduled-latency
+        // breakdown.
+        let _ = step_ns;
+    }
+    let total = bench_start.elapsed();
+
+    println!("hft-clob-core co_bench: add_cancel_mix (closed-loop, CO-corrected)");
+    println!("  target rate     {target_rate} ops/sec");
+    println!("  interval        {interval_ns} ns");
+    println!("  warmup ops      {N_WARMUP}");
+    println!("  measurement ops {N_MEASURE}");
+    println!("  total wall      {} ms", total.as_millis());
+    println!();
+    println!("  p50    {} ns", hist.value_at_quantile(0.50));
+    println!("  p99    {} ns", hist.value_at_quantile(0.99));
+    println!("  p99.9  {} ns", hist.value_at_quantile(0.999));
+    println!("  p99.99 {} ns", hist.value_at_quantile(0.9999));
+    println!("  max    {} ns", hist.max());
+}


### PR DESCRIPTION
## Summary
- New `co_bench` binary — closed-loop driver at a configurable target arrival rate (`TARGET_OPS_PER_SEC` env var). Spin-waits to `bench_start + i * interval`, records `scheduled.elapsed()`, and uses `Histogram::record_correct(value, interval_ns)` to backfill missed intervals.
- BENCH.md "Closed-loop CO-corrected" section with captured numbers at 100k ops/sec target on M4 Max: **CO-corrected p99.9 ≈ 1.21 ms** vs open-loop's 210 µs. Methodology row in the top table updates from "None" to point at this section.
- Makefile: `make co-bench RATE=100000`.

Closes #48.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 233 / 233 pass.
- [x] `cargo build --release`
- [x] `TARGET_OPS_PER_SEC=100000 cargo run --release --bin co_bench` produces the documented percentile table.