### PR TITLE
chore(docker): OCI image labels for GHCR linking

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,17 @@ RUN cargo build --release --workspace --bins
 
 # ---------- runtime: alpine + binaries -----------------------------------
 FROM ${ALPINE_IMAGE} AS runtime
+
+# OCI image annotations — GHCR auto-links the package to the repo
+# from `org.opencontainers.image.source` and surfaces title /
+# description / licenses on the package page.
+LABEL org.opencontainers.image.title="hft-clob-core"
+LABEL org.opencontainers.image.description="Single-symbol CLOB matching engine in Rust — integer-only hot path, deterministic replay, microsecond-class tail latency."
+LABEL org.opencontainers.image.source="https://github.com/joaquinbejar/hft-clob-core"
+LABEL org.opencontainers.image.url="https://github.com/joaquinbejar/hft-clob-core"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="joaquinbejar"
+
 RUN apk add --no-cache ca-certificates && \
     addgroup -g 1000 engine && \
     adduser -u 1000 -G engine -s /bin/sh -D engine


### PR DESCRIPTION
## Summary
Adds the standard `org.opencontainers.image.*` annotations on the runtime stage so GHCR auto-links the package to the source repo and surfaces title / description / license / vendor on the package page.

`version` / `revision` are passed at build time via `--label`, not baked into the Dockerfile.

## Test plan
- [x] `docker build -f docker/Dockerfile -t ghcr.io/joaquinbejar/hft-clob-core:v0.1.0 .` succeeds.
- [x] `docker push ghcr.io/joaquinbejar/hft-clob-core:v0.1.0` succeeds.
- [x] Package created at `ghcr.io/joaquinbejar/hft-clob-core` (visible at https://github.com/users/joaquinbejar/packages/container/package/hft-clob-core).