### PR TITLE
Re-match lose-priority cancel-replace through the book (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ record carries the residual qty and price), the walk halts, and
 `Cancelled{SelfTradePrevented}` for the taker — regardless of TIF,
 including `Gtc` and `Ioc`.
 
+STP fires on **every** aggressive entry, including a cancel-replace
+that reprices through the spread onto the account's own resting
+order: both the repriced order and the resting maker cancel,
+exactly as if a new order had arrived at that level. Each side gets
+its own `Cancelled{SelfTradePrevented}` report, so clients can
+reconstruct causality. Note the policy is **account-scoped** —
+broader than CME's SMP-group model — so a single account can never
+cross its own quotes; two-sided quoting is safe only while the
+account's own bid stays below its own ask.
+
 **Why cancel-both, not "cancel maker, fill taker against the next
 queue entry"**: the cancel-both policy is the cleanest way to
 prevent wash-trade-like patterns from appearing on the public
@@ -259,15 +269,44 @@ the spec references in `doc/DESIGN.md` § 5.2.
 
 Strict qty-down with no price change preserves FIFO position via
 `pricelevel::UpdateQuantity` in place — `ReplaceOutcome { kept_priority: true }`.
-Any price change or qty-up loses priority: the existing order is
-cancelled and the new `(price, qty)` is added at the tail of the
-new level — `kept_priority: false`.
+Any price change or qty-up loses priority — including a qty-down
+**with** a price change (CME iLink rule: any price change goes to
+the back of the new level's queue) — `kept_priority: false`.
+
+The lose-priority path re-submits the new `(price, qty)` through
+the same matching walk a brand-new order goes through, honoring the
+order's stored TIF (issue #59; NASDAQ OUCH / CME iLink semantics —
+a marketable modify executes):
+
+- A reprice through the opposite touch **trades**; only the
+  non-crossing residual rests, at the tail of its level.
+- The order keeps its original `order_id` through any fills. The
+  stream sequence makes this reconstructable: the non-terminal
+  `Replaced` ack (`leaves_qty = new_qty`) is emitted **first**,
+  then trade prints and maker/taker fill reports decrement it,
+  ending in a terminal `Filled`/`Cancelled` when the order does
+  not survive.
+- A reprice onto the account's own resting order fires STP
+  cancel-both (see above) — nothing rests.
+- A resting `PostOnly` order repriced to a would-cross price is
+  rejected with `PostOnlyWouldCross` and **zero book mutation** —
+  the original order stays resting, preserving its never-take
+  guarantee.
+- Only the owning account may replace an order; a foreign replace
+  is rejected as `UnknownOrderId` so order ids do not leak across
+  accounts.
 
 **Why qty-up loses priority**: bumping a resting order's qty up at
 the head of the queue would let a passive participant claim a
 priority advantage they did not earn. Cancel-and-readd is the
 unambiguous way to enforce that. Same rationale for any price
 change: the new price's queue is unrelated to the old one.
+
+**Report-shape asymmetry (known)**: a new order that partially
+fills emits its fills first and then an `Accepted` for the
+residual, while a replace acks first (`Replaced`) and lets the
+fill reports follow. Unifying the two sequences would change the
+golden replay fixture; tracked as a follow-up.
 
 ### Market order in a thin book
 
@@ -291,6 +330,12 @@ such order can arrive); inside `match_aggressive`, the loop
 verifies `taker_price >= level_price` (Bid) / `<=` (Ask) at every
 level entry, so by construction the post-step book has
 `best_bid < best_ask`.
+
+This invariant now covers the cancel-replace path too: before
+issue #59 a lose-priority reprice through the spread rested the
+new price without re-matching, leaving the book crossed. The
+`book_not_crossed` proptest asserts `best_bid < best_ask` after
+every operation in random add / cancel / replace sequences.
 
 ### Post-only
 

--- a/crates/engine/benches/add_cancel_mix.rs
+++ b/crates/engine/benches/add_cancel_mix.rs
@@ -104,7 +104,7 @@ fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
     for _ in 0..n {
         let r = rng.next() % 100;
         let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
-        let side = if rng.next().is_multiple_of(2) {
+        let side = if rng.next() % 2 == 0 {
             Side::Bid
         } else {
             Side::Ask

--- a/crates/engine/src/bin/co_bench.rs
+++ b/crates/engine/src/bin/co_bench.rs
@@ -97,7 +97,7 @@ fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
     for _ in 0..n {
         let r = rng.next() % 100;
         let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
-        let side = if rng.next().is_multiple_of(2) {
+        let side = if rng.next() % 2 == 0 {
             Side::Bid
         } else {
             Side::Ask

--- a/crates/engine/src/bin/dhat_bench.rs
+++ b/crates/engine/src/bin/dhat_bench.rs
@@ -96,7 +96,7 @@ fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
     for _ in 0..n {
         let r = rng.next() % 100;
         let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
-        let side = if rng.next().is_multiple_of(2) {
+        let side = if rng.next() % 2 == 0 {
             Side::Bid
         } else {
             Side::Ask

--- a/crates/engine/src/bin/engine.rs
+++ b/crates/engine/src/bin/engine.rs
@@ -155,7 +155,7 @@ fn engine_loop(rx: mpsc::Receiver<Inbound>, sink: ChannelSink) {
     while let Ok(msg) = rx.recv() {
         engine.step(msg);
         count = count.wrapping_add(1);
-        if count.is_multiple_of(10_000) && count != last_log {
+        if count % 10_000 == 0 && count != last_log {
             eprintln!("engine: processed {count} inbound commands");
             last_log = count;
         }

--- a/crates/engine/src/bin/smoke_bench.rs
+++ b/crates/engine/src/bin/smoke_bench.rs
@@ -81,7 +81,7 @@ fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
     for _ in 0..n {
         let r = rng.next() % 100;
         let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
-        let side = if rng.next().is_multiple_of(2) {
+        let side = if rng.next() % 2 == 0 {
             Side::Bid
         } else {
             Side::Ask

--- a/crates/engine/src/bin/throughput_bench.rs
+++ b/crates/engine/src/bin/throughput_bench.rs
@@ -97,7 +97,7 @@ fn generate_ops(n: u64, seed: u64) -> Vec<Op> {
     for _ in 0..n {
         let r = rng.next() % 100;
         let account = ((rng.next() % ACCOUNT_COUNT) + 1) as u32;
-        let side = if rng.next().is_multiple_of(2) {
+        let side = if rng.next() % 2 == 0 {
             Side::Bid
         } else {
             Side::Ask

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -368,105 +368,13 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             return;
         }
 
-        // Stage 4b: emit per-fill. For each fill we publish the trade
-        // print and the two corresponding exec reports (maker + taker
-        // partial / full). Order: trade print first, then exec
-        // reports — `engine_seq` strictly monotonic across all three.
-        let mut taker_remaining_lots = msg.qty.as_lots();
-        // Snapshot len before mutating; clippy would flag the implicit
-        // borrow if we reused `&self.fills_buf` in the loop body.
-        let fills_count = self.fills_buf.len();
-        for i in 0..fills_count {
-            let fill = self.fills_buf[i];
-            taker_remaining_lots = taker_remaining_lots.saturating_sub(fill.qty.as_lots());
-            self.emit_trade_print_for_fill(&fill, msg.side, recv_ts);
-            // Maker exec report.
-            let maker_acct = self
-                .registry
-                .get(&fill.maker_order_id)
-                .map(|e| e.account_id)
-                .unwrap_or(msg.account_id);
-            let maker_state = if fill.maker_fully_filled {
-                ExecState::Filled
-            } else {
-                ExecState::PartiallyFilled
-            };
-            // Compute the maker's residual qty AFTER this fill so the
-            // partial-fill exec report's `leaves_qty` is correct.
-            // Full-fill terminates the maker → leaves is None.
-            let maker_leaves = if fill.maker_fully_filled {
-                None
-            } else {
-                self.registry.get(&fill.maker_order_id).and_then(|e| {
-                    let new_lots = e.qty.as_lots().saturating_sub(fill.qty.as_lots());
-                    Qty::new(new_lots).ok()
-                })
-            };
-            self.emit_exec_report_fill(
-                fill.maker_order_id,
-                maker_acct,
-                maker_state,
-                fill.price,
-                fill.qty,
-                maker_leaves,
-                recv_ts,
-            );
-            // Taker exec report — partial until the last fill that
-            // empties the taker, then Filled.
-            let taker_state = if taker_remaining_lots == 0 {
-                ExecState::Filled
-            } else {
-                ExecState::PartiallyFilled
-            };
-            let taker_leaves = if taker_remaining_lots == 0 {
-                None
-            } else {
-                Qty::new(taker_remaining_lots).ok()
-            };
-            self.emit_exec_report_fill(
-                msg.order_id,
-                msg.account_id,
-                taker_state,
-                fill.price,
-                fill.qty,
-                taker_leaves,
-                recv_ts,
-            );
-            // Risk-state book-keeping for the maker. Full fill drops
-            // the registry entry and refunds the resting notional.
-            self.risk.on_fill(fill.price);
-            if fill.maker_fully_filled {
-                if let Some(entry) = self.registry.remove(&fill.maker_order_id) {
-                    self.risk.on_order_removed(entry.account_id, entry.notional);
-                }
-            } else if let Some(entry) = self.registry.get_mut(&fill.maker_order_id) {
-                let consumed_notional = notional_of(fill.price, fill.qty);
-                let new_notional = entry.notional.saturating_sub(consumed_notional);
-                let new_qty_lots = entry.qty.as_lots().saturating_sub(fill.qty.as_lots());
-                self.risk
-                    .on_order_removed(entry.account_id, consumed_notional);
-                entry.notional = new_notional;
-                if let Ok(q) = Qty::new(new_qty_lots) {
-                    entry.qty = q;
-                }
-            }
-        }
+        // Stage 4b: per-fill emission + maker book-keeping (shared
+        // with the cancel-replace handler).
+        self.emit_fills_for_taker(msg.order_id, msg.account_id, msg.qty, recv_ts);
 
-        // Stage 4c: per-STP-cancel — emit a Cancelled exec report for
-        // each maker dropped, plus refund risk state.
-        let stp_count = self.stp_buf.len();
-        for i in 0..stp_count {
-            let stp = self.stp_buf[i];
-            self.emit_exec_report_cancelled(
-                stp.order_id,
-                stp.account_id,
-                CancelReason::SelfTradePrevented,
-                recv_ts,
-            );
-            if let Some(entry) = self.registry.remove(&stp.order_id) {
-                self.risk.on_order_removed(entry.account_id, entry.notional);
-            }
-        }
+        // Stage 4c: per-STP-cancel emission + refunds (shared with
+        // the cancel-replace handler).
+        self.emit_stp_cancels(recv_ts);
 
         // Stage 4d: taker terminal disposition. STP cancels the taker
         // unconditionally (regardless of TIF). Otherwise route by TIF.
@@ -616,13 +524,10 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             return;
         }
         // Snapshot the old registry entry so we can refund the old
-        // notional and re-register the new one once the replace
+        // notional and re-register the residual once the replace
         // commits.
         let old_entry = self.registry.get(&msg.order_id).copied();
         // Scratch buffers reused; a lose-priority reprice can trade.
-        // NOTE: fill / STP emission for these buffers lands in the
-        // follow-up engine commit; this call only adopts the new
-        // matching-core signature.
         self.fills_buf.clear();
         self.stp_buf.clear();
         let outcome: Result<ReplaceOutcome, _> = self.book.replace(
@@ -633,40 +538,102 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             &mut self.fills_buf,
             &mut self.stp_buf,
         );
-        match outcome {
-            Ok(replaced) => {
-                if let Some(entry) = old_entry {
-                    self.risk.on_order_removed(entry.account_id, entry.notional);
-                }
-                let new_notional = notional_of(msg.new_price, msg.new_qty);
-                if let Err(reason) = self.risk.on_order_resting(msg.account_id, new_notional) {
-                    // Replace-up would blow the cap. Roll back: the
-                    // matching core has already mutated the book, so
-                    // we cancel the residual to maintain invariants.
-                    let _ = self.book.cancel(msg.order_id);
-                    self.registry.remove(&msg.order_id);
-                    self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
-                } else {
-                    self.registry.insert(
-                        msg.order_id,
-                        OrderRegistryEntry {
-                            account_id: msg.account_id,
-                            side: old_entry.map(|e| e.side).unwrap_or(Side::Bid),
-                            qty: msg.new_qty,
-                            notional: new_notional,
-                        },
-                    );
-                    let _ = replaced;
-                    self.emit_exec_report_replaced(msg.order_id, msg.account_id, recv_ts);
-                }
+        let replaced = match outcome {
+            Ok(replaced) => replaced,
+            Err(_) => {
+                self.emit_rejected(
+                    msg.order_id,
+                    msg.account_id,
+                    RejectReason::UnknownOrderId,
+                    recv_ts,
+                );
+                return;
             }
-            Err(_) => self.emit_rejected(
+        };
+
+        // A would-cross reprice of a resting PostOnly order was
+        // rejected by the matching core with zero book mutation — the
+        // original order is still resting at its old (price, qty), so
+        // risk / registry state stays exactly as it was.
+        if replaced
+            .match_result
+            .is_some_and(|r| r.taker_post_only_rejected)
+        {
+            self.emit_rejected(
                 msg.order_id,
                 msg.account_id,
-                RejectReason::UnknownOrderId,
+                RejectReason::PostOnlyWouldCross,
                 recv_ts,
-            ),
+            );
+            return;
         }
+
+        // The replace committed: the old (price, qty) incarnation is
+        // gone. Refund its notional and drop its registry entry; the
+        // residual (if any) is re-registered below with its own
+        // notional.
+        if let Some(entry) = old_entry {
+            self.risk.on_order_removed(entry.account_id, entry.notional);
+        }
+        self.registry.remove(&msg.order_id);
+
+        // Replaced ack FIRST (OUCH-style): the modify committed, the
+        // order now stands at (new_price, new_qty). Non-terminal —
+        // `leaves_qty = new_qty`; any fills follow under later seqs
+        // and decrement it, ending in a terminal Filled / Cancelled
+        // when the order does not survive.
+        self.emit_exec_report_replaced(msg.order_id, msg.account_id, msg.new_qty, recv_ts);
+
+        // Fill + STP emission, shared with handle_new_order. On the
+        // kept-priority path both buffers are empty and these are
+        // no-ops.
+        self.emit_fills_for_taker(msg.order_id, msg.account_id, msg.new_qty, recv_ts);
+        self.emit_stp_cancels(recv_ts);
+
+        // Taker disposition. `match_result` is None on the
+        // kept-priority in-place path: nothing traded, the full new
+        // qty rests.
+        let (taker_stp_cancelled, taker_remaining) = match replaced.match_result {
+            Some(r) => (r.taker_stp_cancelled, r.taker_remaining),
+            None => (false, Some(msg.new_qty)),
+        };
+        if taker_stp_cancelled {
+            // Cancel-both STP: the repriced order was dropped by the
+            // walk and did not rest.
+            self.emit_exec_report_cancelled(
+                msg.order_id,
+                msg.account_id,
+                CancelReason::SelfTradePrevented,
+                recv_ts,
+            );
+        } else if let Some(remaining) = taker_remaining {
+            let resting_notional = notional_of(msg.new_price, remaining);
+            if let Err(reason) = self.risk.on_order_resting(msg.account_id, resting_notional) {
+                // The residual would blow the account cap. Fills
+                // stand — trades are unrollbackable — so cancel only
+                // the resting remainder.
+                let _ = self.book.cancel(msg.order_id);
+                self.emit_rejected(msg.order_id, msg.account_id, reason, recv_ts);
+            } else {
+                self.registry.insert(
+                    msg.order_id,
+                    OrderRegistryEntry {
+                        account_id: msg.account_id,
+                        // The book is authoritative for the side; the
+                        // registry snapshot is a mirror. Fall back to
+                        // the fill's maker side when the mirror was
+                        // out of sync (defensive, unreachable in a
+                        // consistent pipeline).
+                        side: old_entry.map(|e| e.side).unwrap_or(Side::Bid),
+                        qty: remaining,
+                        notional: resting_notional,
+                    },
+                );
+            }
+        }
+        // taker_remaining == None: fully filled by the reprice — the
+        // last taker fill report was terminal Filled and the registry
+        // entry is already gone.
         // Book changes emitted in `step` after handler returns.
     }
 
@@ -723,6 +690,124 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
 
     fn next_seq(&mut self) -> EngineSeq {
         self.ids.next_engine_seq()
+    }
+
+    /// Per-fill emission + maker book-keeping over `fills_buf`.
+    /// Shared by the new-order and cancel-replace handlers: for each
+    /// fill publish the trade print and the two exec reports (maker +
+    /// taker, partial / full), bump the risk price-band reference,
+    /// and consume the maker's registry entry / resting notional.
+    /// Order per fill: trade print first, then exec reports —
+    /// `engine_seq` strictly monotonic across all three. The
+    /// aggressor side is derived per fill (`maker_side.opposite()`),
+    /// so the caller only supplies the taker's identity and its
+    /// pre-walk qty (for `leaves_qty` computation).
+    fn emit_fills_for_taker(
+        &mut self,
+        taker_order_id: OrderId,
+        taker_account: AccountId,
+        taker_qty: Qty,
+        recv_ts: RecvTs,
+    ) {
+        let mut taker_remaining_lots = taker_qty.as_lots();
+        // Snapshot len before mutating; clippy would flag the implicit
+        // borrow if we reused `&self.fills_buf` in the loop body.
+        let fills_count = self.fills_buf.len();
+        for i in 0..fills_count {
+            let fill = self.fills_buf[i];
+            taker_remaining_lots = taker_remaining_lots.saturating_sub(fill.qty.as_lots());
+            self.emit_trade_print_for_fill(&fill, fill.maker_side.opposite(), recv_ts);
+            // Maker exec report.
+            let maker_acct = self
+                .registry
+                .get(&fill.maker_order_id)
+                .map(|e| e.account_id)
+                .unwrap_or(taker_account);
+            let maker_state = if fill.maker_fully_filled {
+                ExecState::Filled
+            } else {
+                ExecState::PartiallyFilled
+            };
+            // Compute the maker's residual qty AFTER this fill so the
+            // partial-fill exec report's `leaves_qty` is correct.
+            // Full-fill terminates the maker → leaves is None.
+            let maker_leaves = if fill.maker_fully_filled {
+                None
+            } else {
+                self.registry.get(&fill.maker_order_id).and_then(|e| {
+                    let new_lots = e.qty.as_lots().saturating_sub(fill.qty.as_lots());
+                    Qty::new(new_lots).ok()
+                })
+            };
+            self.emit_exec_report_fill(
+                fill.maker_order_id,
+                maker_acct,
+                maker_state,
+                fill.price,
+                fill.qty,
+                maker_leaves,
+                recv_ts,
+            );
+            // Taker exec report — partial until the last fill that
+            // empties the taker, then Filled.
+            let taker_state = if taker_remaining_lots == 0 {
+                ExecState::Filled
+            } else {
+                ExecState::PartiallyFilled
+            };
+            let taker_leaves = if taker_remaining_lots == 0 {
+                None
+            } else {
+                Qty::new(taker_remaining_lots).ok()
+            };
+            self.emit_exec_report_fill(
+                taker_order_id,
+                taker_account,
+                taker_state,
+                fill.price,
+                fill.qty,
+                taker_leaves,
+                recv_ts,
+            );
+            // Risk-state book-keeping for the maker. Full fill drops
+            // the registry entry and refunds the resting notional.
+            self.risk.on_fill(fill.price);
+            if fill.maker_fully_filled {
+                if let Some(entry) = self.registry.remove(&fill.maker_order_id) {
+                    self.risk.on_order_removed(entry.account_id, entry.notional);
+                }
+            } else if let Some(entry) = self.registry.get_mut(&fill.maker_order_id) {
+                let consumed_notional = notional_of(fill.price, fill.qty);
+                let new_notional = entry.notional.saturating_sub(consumed_notional);
+                let new_qty_lots = entry.qty.as_lots().saturating_sub(fill.qty.as_lots());
+                self.risk
+                    .on_order_removed(entry.account_id, consumed_notional);
+                entry.notional = new_notional;
+                if let Ok(q) = Qty::new(new_qty_lots) {
+                    entry.qty = q;
+                }
+            }
+        }
+    }
+
+    /// Per-STP-cancel emission + refunds over `stp_buf`. Shared by
+    /// the new-order and cancel-replace handlers: one
+    /// `Cancelled{SelfTradePrevented}` exec report per dropped maker,
+    /// plus registry / resting-notional refund.
+    fn emit_stp_cancels(&mut self, recv_ts: RecvTs) {
+        let stp_count = self.stp_buf.len();
+        for i in 0..stp_count {
+            let stp = self.stp_buf[i];
+            self.emit_exec_report_cancelled(
+                stp.order_id,
+                stp.account_id,
+                CancelReason::SelfTradePrevented,
+                recv_ts,
+            );
+            if let Some(entry) = self.registry.remove(&stp.order_id) {
+                self.risk.on_order_removed(entry.account_id, entry.notional);
+            }
+        }
     }
 
     fn emit_rejected(
@@ -810,13 +895,16 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
         // Replace lose-priority vs keep-priority is signalled at the
         // matching layer; the wire `ExecReport` does not surface it
         // (a follow-up wires a dedicated bit for that).
+        new_qty: Qty,
         recv_ts: RecvTs,
     ) {
-        // The wire `ExecReport` does not carry `kept_priority` as a
-        // field; that signal lives in `CancelReason::Replaced` paired
-        // with a follow-up `Accepted` for the new resting order in
-        // the lose-priority case. v1 emits a single `Replaced`
-        // terminal exec report for the old order id.
+        // Non-terminal modify ack, emitted BEFORE any fills the
+        // reprice produces (OUCH-style: ack first, executions after).
+        // `leaves_qty = new_qty` — the order stands at the new
+        // (price, qty) as of this seq; later fill reports decrement
+        // it. `cancel_reason: Replaced` marks the end of the old
+        // (price, qty) incarnation, not of the order: the same
+        // order_id lives on.
         let report = ExecReport {
             engine_seq: self.next_seq(),
             order_id,
@@ -824,7 +912,7 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             state: ExecState::Replaced,
             fill_price: None,
             fill_qty: None,
-            leaves_qty: None,
+            leaves_qty: Some(new_qty),
             reject_reason: None,
             cancel_reason: Some(CancelReason::Replaced),
             recv_ts,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -619,8 +619,20 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
         // notional and re-register the new one once the replace
         // commits.
         let old_entry = self.registry.get(&msg.order_id).copied();
-        let outcome: Result<ReplaceOutcome, _> =
-            self.book.replace(msg.order_id, msg.new_price, msg.new_qty);
+        // Scratch buffers reused; a lose-priority reprice can trade.
+        // NOTE: fill / STP emission for these buffers lands in the
+        // follow-up engine commit; this call only adopts the new
+        // matching-core signature.
+        self.fills_buf.clear();
+        self.stp_buf.clear();
+        let outcome: Result<ReplaceOutcome, _> = self.book.replace(
+            msg.order_id,
+            msg.new_price,
+            msg.new_qty,
+            &mut self.ids,
+            &mut self.fills_buf,
+            &mut self.stp_buf,
+        );
         match outcome {
             Ok(replaced) => {
                 if let Some(entry) = old_entry {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -499,6 +499,7 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
                         side: msg.side,
                         price,
                         qty: remaining,
+                        tif: msg.tif,
                     };
                     let resting_notional = notional_of(price, remaining);
                     // Risk re-confirms the post-trade caps before

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -527,6 +527,23 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
         // notional and re-register the residual once the replace
         // commits.
         let old_entry = self.registry.get(&msg.order_id).copied();
+        // Ownership gate: only the owning account may replace the
+        // order. This matters post-#59 — a replace can now trade and
+        // fire STP under the requester's account, so a cross-account
+        // replace would book fills and notional incoherently. Report
+        // UnknownOrderId rather than a dedicated reason so foreign
+        // order ids do not leak across accounts.
+        if let Some(entry) = old_entry
+            && entry.account_id != msg.account_id
+        {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::UnknownOrderId,
+                recv_ts,
+            );
+            return;
+        }
         // Scratch buffers reused; a lose-priority reprice can trade.
         self.fills_buf.clear();
         self.stp_buf.clear();

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -587,6 +587,54 @@ fn cancel_replace_onto_own_order_stp_cancels_both() {
 }
 
 #[test]
+fn cancel_replace_from_non_owner_is_rejected_book_unchanged() {
+    use domain::{ExecState, RejectReason};
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    engine.step(Inbound::NewOrder(limit_order(1, 2, Side::Ask, 100, 10)));
+    engine.step(Inbound::NewOrder(limit_order(2, 7, Side::Bid, 99, 10)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Account 9 tries to reprice account 7's order through the
+    // spread. Must reject (as UnknownOrderId — no cross-account id
+    // leak) with zero book mutation.
+    engine.step(cancel_replace(2, 9, 100, 10));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    let rejects: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) if r.state == ExecState::Rejected => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejects.len(), 1);
+    assert_eq!(rejects[0].reject_reason, Some(RejectReason::UnknownOrderId));
+    assert!(!events.iter().any(|o| matches!(o, Outbound::TradePrint(_))));
+
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    assert_eq!(
+        top.bid.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((99, 10))
+    );
+    assert_eq!(
+        top.ask.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((100, 10))
+    );
+}
+
+#[test]
 fn cancel_replace_postonly_would_cross_is_rejected_book_unchanged() {
     use domain::{ExecState, RejectReason};
 

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -46,7 +46,7 @@ fn smoke_100_orders_engine_seq_is_strictly_monotonic_after_decode() {
     for i in 0..50u64 {
         let id = 1000 + i;
         // Some buys cross (price >= 100), some don't (rest at 50..).
-        let price = if i.is_multiple_of(2) { 200 } else { 50 };
+        let price = if i % 2 == 0 { 200 } else { 50 };
         let qty = (i % 5) + 1;
         engine.step(Inbound::NewOrder(limit_order(id, 7, Side::Bid, price, qty)));
     }

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -383,3 +383,262 @@ fn engine_inner_sink(engine: &mut Engine<StubClock, CounterIdGenerator, VecSink>
     // `sink_mut` helper for this purpose.
     engine.sink_mut()
 }
+
+// ---------------------------------------------------------------------
+// Cancel-replace re-match (issue #59)
+// ---------------------------------------------------------------------
+
+fn cancel_replace(id: u64, account: u32, new_price: i64, new_qty: u64) -> wire::inbound::Inbound {
+    Inbound::CancelReplace(wire::inbound::CancelReplace {
+        client_ts: ClientTs::new(0),
+        order_id: OrderId::new(id).expect("ok"),
+        account_id: AccountId::new(account).expect("ok"),
+        new_price: Price::new(new_price).expect("ok"),
+        new_qty: Qty::new(new_qty).expect("ok"),
+    })
+}
+
+#[test]
+fn cancel_replace_through_spread_emits_replaced_then_fills_and_flattens_book() {
+    use domain::{CancelReason, ExecState};
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    // SELL 10@100 (acct 2), BUY 10@99 (acct 7) — non-crossing.
+    engine.step(Inbound::NewOrder(limit_order(1, 2, Side::Ask, 100, 10)));
+    engine.step(Inbound::NewOrder(limit_order(2, 7, Side::Bid, 99, 10)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Reprice the buy through the spread: must trade in full.
+    engine.step(cancel_replace(2, 7, 100, 10));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Exactly one trade print for the full 10 lots at 100.
+    let trades: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::TradePrint(t) => Some(t),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(trades.len(), 1);
+    assert_eq!(trades[0].price.as_ticks(), 100);
+    assert_eq!(trades[0].qty.as_lots(), 10);
+
+    // Exec-report sequence on the wire: the non-terminal Replaced ack
+    // (leaves = new_qty) comes FIRST, then the maker + taker fill
+    // reports (both terminal Filled).
+    let reports: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(reports.len(), 3);
+    assert_eq!(reports[0].state, ExecState::Replaced);
+    assert_eq!(reports[0].order_id, OrderId::new(2).expect("ok"));
+    assert_eq!(reports[0].cancel_reason, Some(CancelReason::Replaced));
+    assert_eq!(reports[0].leaves_qty.map(|q| q.as_lots()), Some(10));
+    assert_eq!(reports[1].state, ExecState::Filled);
+    assert_eq!(reports[1].order_id, OrderId::new(1).expect("ok"));
+    assert_eq!(reports[2].state, ExecState::Filled);
+    assert_eq!(reports[2].order_id, OrderId::new(2).expect("ok"));
+    assert_eq!(reports[2].leaves_qty, None);
+
+    // The replace ack precedes the trade print in the raw stream.
+    let replaced_pos = events
+        .iter()
+        .position(|o| matches!(o, Outbound::ExecReport(r) if r.state == ExecState::Replaced))
+        .expect("replaced ack present");
+    let trade_pos = events
+        .iter()
+        .position(|o| matches!(o, Outbound::TradePrint(_)))
+        .expect("trade print present");
+    assert!(replaced_pos < trade_pos);
+
+    // engine_seq strictly monotonic across the step's emissions.
+    let mut last = 0u64;
+    for ev in &events {
+        let seq = match ev {
+            Outbound::ExecReport(r) => r.engine_seq.as_raw(),
+            Outbound::TradePrint(t) => t.engine_seq.as_raw(),
+            Outbound::BookUpdateTop(b) => b.engine_seq.as_raw(),
+            Outbound::BookUpdateL2Delta(d) => d.engine_seq.as_raw(),
+            Outbound::SnapshotResponse(s) => s.engine_seq.as_raw(),
+        };
+        assert!(seq > last, "engine_seq not monotonic: {last} -> {seq}");
+        last = seq;
+    }
+
+    // Book flat on both sides — never crossed.
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    assert_eq!(top.bid, None);
+    assert_eq!(top.ask, None);
+}
+
+#[test]
+fn cancel_replace_partial_cross_rests_residual_at_new_price() {
+    use domain::ExecState;
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    // SELL 4@100 (acct 2), BUY 10@99 (acct 7).
+    engine.step(Inbound::NewOrder(limit_order(1, 2, Side::Ask, 100, 4)));
+    engine.step(Inbound::NewOrder(limit_order(2, 7, Side::Bid, 99, 10)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Reprice the buy to 100: 4 lots trade, 6 rest at 100.
+    engine.step(cancel_replace(2, 7, 100, 10));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    let reports: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    // Replaced ack + maker Filled + taker PartiallyFilled.
+    assert_eq!(reports.len(), 3);
+    assert_eq!(reports[0].state, ExecState::Replaced);
+    assert_eq!(reports[1].state, ExecState::Filled);
+    assert_eq!(reports[2].state, ExecState::PartiallyFilled);
+    assert_eq!(reports[2].leaves_qty.map(|q| q.as_lots()), Some(6));
+
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    // Residual rests as best bid at 100; ask side empty.
+    assert_eq!(
+        top.bid.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((100, 6))
+    );
+    assert_eq!(top.ask, None);
+}
+
+#[test]
+fn cancel_replace_onto_own_order_stp_cancels_both() {
+    use domain::{CancelReason, ExecState};
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    // Same account (7) on both sides.
+    engine.step(Inbound::NewOrder(limit_order(1, 7, Side::Ask, 100, 10)));
+    engine.step(Inbound::NewOrder(limit_order(2, 7, Side::Bid, 99, 10)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Reprice the bid onto the account's own ask: cancel-both.
+    engine.step(cancel_replace(2, 7, 100, 10));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    assert!(
+        !events.iter().any(|o| matches!(o, Outbound::TradePrint(_))),
+        "self-trade must not print"
+    );
+    let cancelled: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) if r.state == ExecState::Cancelled => Some(r),
+            _ => None,
+        })
+        .collect();
+    // Maker (id 1) and repriced taker (id 2), both SelfTradePrevented.
+    assert_eq!(cancelled.len(), 2);
+    assert!(
+        cancelled
+            .iter()
+            .all(|r| r.cancel_reason == Some(CancelReason::SelfTradePrevented))
+    );
+    assert_eq!(cancelled[0].order_id, OrderId::new(1).expect("ok"));
+    assert_eq!(cancelled[1].order_id, OrderId::new(2).expect("ok"));
+
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    assert_eq!(top.bid, None);
+    assert_eq!(top.ask, None);
+}
+
+#[test]
+fn cancel_replace_postonly_would_cross_is_rejected_book_unchanged() {
+    use domain::{ExecState, RejectReason};
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    engine.step(Inbound::NewOrder(limit_order(1, 2, Side::Ask, 100, 10)));
+    let mut post_only = limit_order(2, 7, Side::Bid, 99, 10);
+    post_only.tif = Tif::PostOnly;
+    engine.step(Inbound::NewOrder(post_only));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Repricing the resting PostOnly bid through the spread must be
+    // rejected outright — never-take guarantee — with zero mutation.
+    engine.step(cancel_replace(2, 7, 100, 10));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    let rejects: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) if r.state == ExecState::Rejected => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejects.len(), 1);
+    assert_eq!(rejects[0].order_id, OrderId::new(2).expect("ok"));
+    assert_eq!(
+        rejects[0].reject_reason,
+        Some(RejectReason::PostOnlyWouldCross)
+    );
+    assert!(
+        !events.iter().any(|o| matches!(o, Outbound::TradePrint(_))),
+        "no trade may print"
+    );
+
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    // Original order untouched at 99; ask untouched at 100.
+    assert_eq!(
+        top.bid.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((99, 10))
+    );
+    assert_eq!(
+        top.ask.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((100, 10))
+    );
+}

--- a/crates/matching/src/book.rs
+++ b/crates/matching/src/book.rs
@@ -497,20 +497,44 @@ impl Book {
 
     /// Cancel-and-replace a resting order. Priority is preserved
     /// only on a strict qty-down with no price change; any price
-    /// change or qty-up loses priority (cancel + re-add at the new
-    /// `(price, qty)`). Returns a [`ReplaceOutcome`] carrying
+    /// change or qty-up loses priority — CME iLink rule: qty-down
+    /// *with* a price change still goes to the back of the new
+    /// level's queue. Returns a [`ReplaceOutcome`] carrying
     /// `kept_priority` so the engine pipeline can stamp the
     /// `Replaced{kept_priority}` exec report correctly.
+    ///
+    /// The lose-priority path re-submits the new `(price, qty)`
+    /// through [`Book::match_aggressive`] under the order's stored
+    /// TIF — exactly the walk a brand-new order goes through — and
+    /// rests only the residual that does not cross (issue #59: the
+    /// old cancel-plus-re-add path rested a crossed book). The order
+    /// keeps its original `order_id` through any fills.
+    /// Consequences the caller must handle via `out_fills` /
+    /// `out_stp` and [`ReplaceOutcome::match_result`]:
+    ///
+    /// - A reprice through the opposite touch trades; fills are
+    ///   appended to `out_fills` with trade ids from `ids`.
+    /// - Self-trade prevention applies as on any aggressive entry:
+    ///   a reprice onto the account's own resting order cancels
+    ///   both (maker record in `out_stp`,
+    ///   [`MatchResult::taker_stp_cancelled`] set, nothing rests).
+    /// - A resting `PostOnly` order repriced to a would-cross price
+    ///   is rejected via [`MatchResult::taker_post_only_rejected`]
+    ///   with **zero book mutation** — the original order stays
+    ///   resting untouched, preserving its never-take guarantee.
     ///
     /// # Errors
     /// - [`BookError::UnknownOrderId`] when `order_id` is not present.
     /// - [`BookError::SeqOverflow`] on the cancel-and-readd path
     ///   when the internal arrival counter would overflow.
-    pub fn replace(
+    pub fn replace<I: IdGenerator>(
         &mut self,
         order_id: OrderId,
         new_price: Price,
         new_qty: Qty,
+        ids: &mut I,
+        out_fills: &mut Vec<Fill>,
+        out_stp: &mut Vec<StpCancellation>,
     ) -> Result<ReplaceOutcome, BookError> {
         let meta = *self.index.get(&order_id).ok_or(BookError::UnknownOrderId)?;
         let current_qty = self.resting_qty(order_id).unwrap_or(Qty::MIN);
@@ -521,7 +545,9 @@ impl Book {
         if kept_priority {
             // In-place qty update via pricelevel. Strict qty-down or
             // no-op (same qty + same price). The level keeps the
-            // order in its FIFO queue; nothing else changes.
+            // order in its FIFO queue; nothing else changes. A
+            // same-price qty-down cannot cross (the order was already
+            // resting at that price), so no matching walk is needed.
             let level = match meta.side {
                 Side::Bid => self.bids.get(&meta.price),
                 Side::Ask => self.asks.get(&meta.price),
@@ -531,29 +557,70 @@ impl Book {
                 order_id: PlId::Sequential(order_id.as_raw()),
                 new_quantity: PlQuantity::new(new_qty.as_lots()),
             });
-            // No sidecar mutation: side / price / account_id all
-            // unchanged.
-            Ok(ReplaceOutcome {
+            // No sidecar mutation: side / price / account_id / tif
+            // all unchanged.
+            return Ok(ReplaceOutcome {
                 kept_priority: true,
-            })
-        } else {
-            // Lose-priority path: cancel + re-add at the new
-            // (price, qty). The order joins the tail of the new
-            // level's FIFO queue.
-            let account_id = meta.account_id;
-            self.cancel(order_id)?;
+                match_result: None,
+            });
+        }
+
+        // Lose-priority path. PostOnly gate first, before any
+        // mutation: the single-writer discipline guarantees the
+        // would-cross answer stays valid through the rest of this
+        // call, so rejecting here leaves the original order resting
+        // untouched.
+        if meta.tif == Tif::PostOnly && self.would_cross(meta.side, Some(new_price)) {
+            return Ok(ReplaceOutcome {
+                kept_priority: false,
+                match_result: Some(MatchResult {
+                    fills_count: 0,
+                    stp_cancellations: 0,
+                    taker_remaining: Some(new_qty),
+                    taker_stp_cancelled: false,
+                    taker_post_only_rejected: true,
+                }),
+            });
+        }
+
+        // Cancel, then re-submit the new (price, qty) through the
+        // matching walk. The PostOnly case was already gated above,
+        // so the walk's own arrival gate cannot fire here.
+        let account_id = meta.account_id;
+        self.cancel(order_id)?;
+        let result = self.match_aggressive(
+            AggressiveOrder {
+                order_id,
+                account_id,
+                side: meta.side,
+                price: Some(new_price),
+                qty: new_qty,
+                tif: meta.tif,
+            },
+            ids,
+            out_fills,
+            out_stp,
+        );
+
+        // An STP cancel-both drops the taker too — nothing rests.
+        // Otherwise rest the residual; by construction of the walk
+        // it can no longer cross, so the book stays uncrossed.
+        if !result.taker_stp_cancelled
+            && let Some(remaining) = result.taker_remaining
+        {
             self.add_resting(RestingOrder {
                 order_id,
                 account_id,
                 side: meta.side,
                 price: new_price,
-                qty: new_qty,
+                qty: remaining,
                 tif: meta.tif,
             })?;
-            Ok(ReplaceOutcome {
-                kept_priority: false,
-            })
         }
+        Ok(ReplaceOutcome {
+            kept_priority: false,
+            match_result: Some(result),
+        })
     }
 
     /// Cancel every resting order owned by `account`. Each cancelled
@@ -745,13 +812,24 @@ mod tests {
     }
 
     fn order_acct(id: u64, account: u32, side: Side, price: i64, qty: u64) -> RestingOrder {
+        order_tif(id, account, side, price, qty, Tif::Gtc)
+    }
+
+    fn order_tif(
+        id: u64,
+        account: u32,
+        side: Side,
+        price: i64,
+        qty: u64,
+        tif: Tif,
+    ) -> RestingOrder {
         RestingOrder {
             order_id: OrderId::new(id).expect("valid order_id fixture"),
             account_id: AccountId::new(account).expect("valid account_id fixture"),
             side,
             price: Price::new(price).expect("valid price fixture"),
             qty: Qty::new(qty).expect("valid qty fixture"),
-            tif: Tif::Gtc,
+            tif,
         }
     }
 
@@ -1476,18 +1554,42 @@ mod tests {
     // Replace (cancel-replace)
     // -------------------------------------------------------------------
 
+    /// Drive `Book::replace` with a fresh `MockIds` + scratch buffers,
+    /// returning everything a test needs to assert on.
+    #[allow(clippy::type_complexity)]
+    fn do_replace(
+        book: &mut Book,
+        id: u64,
+        price: i64,
+        qty: u64,
+    ) -> (
+        Result<ReplaceOutcome, BookError>,
+        Vec<Fill>,
+        Vec<StpCancellation>,
+    ) {
+        let mut ids = MockIds::new();
+        let mut fills = Vec::new();
+        let mut stp = stp_buf();
+        let r = book.replace(
+            OrderId::new(id).expect("ok"),
+            Price::new(price).expect("ok"),
+            Qty::new(qty).expect("ok"),
+            &mut ids,
+            &mut fills,
+            &mut stp,
+        );
+        (r, fills, stp)
+    }
+
     #[test]
     fn test_replace_qty_down_same_price_keeps_priority() {
         let mut book = Book::new();
         book.add_resting(order(1, Side::Bid, 100, 10)).expect("add");
-        let outcome = book
-            .replace(
-                OrderId::new(1).expect("ok"),
-                Price::new(100).expect("ok"),
-                Qty::new(7).expect("ok"),
-            )
-            .expect("replace");
+        let (outcome, fills, _) = do_replace(&mut book, 1, 100, 7);
+        let outcome = outcome.expect("replace");
         assert!(outcome.kept_priority);
+        assert_eq!(outcome.match_result, None);
+        assert!(fills.is_empty());
         assert_eq!(book.side_qty(Side::Bid), 7);
         assert_eq!(book.best_bid(), Some(Price::new(100).expect("ok")));
     }
@@ -1496,14 +1598,10 @@ mod tests {
     fn test_replace_qty_up_same_price_loses_priority() {
         let mut book = Book::new();
         book.add_resting(order(1, Side::Bid, 100, 10)).expect("add");
-        let outcome = book
-            .replace(
-                OrderId::new(1).expect("ok"),
-                Price::new(100).expect("ok"),
-                Qty::new(15).expect("ok"),
-            )
-            .expect("replace");
+        let (outcome, fills, _) = do_replace(&mut book, 1, 100, 15);
+        let outcome = outcome.expect("replace");
         assert!(!outcome.kept_priority);
+        assert!(fills.is_empty());
         assert_eq!(book.side_qty(Side::Bid), 15);
         assert_eq!(book.best_bid(), Some(Price::new(100).expect("ok")));
     }
@@ -1512,14 +1610,10 @@ mod tests {
     fn test_replace_price_change_loses_priority() {
         let mut book = Book::new();
         book.add_resting(order(1, Side::Bid, 100, 10)).expect("add");
-        let outcome = book
-            .replace(
-                OrderId::new(1).expect("ok"),
-                Price::new(99).expect("ok"),
-                Qty::new(10).expect("ok"),
-            )
-            .expect("replace");
+        let (outcome, fills, _) = do_replace(&mut book, 1, 99, 10);
+        let outcome = outcome.expect("replace");
         assert!(!outcome.kept_priority);
+        assert!(fills.is_empty());
         assert_eq!(book.best_bid(), Some(Price::new(99).expect("ok")));
         assert_eq!(book.side_qty(Side::Bid), 10);
     }
@@ -1527,11 +1621,7 @@ mod tests {
     #[test]
     fn test_replace_unknown_order_id_returns_err() {
         let mut book = Book::new();
-        let r = book.replace(
-            OrderId::new(99).expect("ok"),
-            Price::new(100).expect("ok"),
-            Qty::new(5).expect("ok"),
-        );
+        let (r, _, _) = do_replace(&mut book, 99, 100, 5);
         assert_eq!(r, Err(BookError::UnknownOrderId));
     }
 
@@ -1542,13 +1632,8 @@ mod tests {
         let mut book = Book::new();
         book.add_resting(order(1, Side::Bid, 100, 5)).expect("add");
         book.add_resting(order(2, Side::Bid, 100, 5)).expect("add");
-        let _ = book
-            .replace(
-                OrderId::new(1).expect("ok"),
-                Price::new(100).expect("ok"),
-                Qty::new(3).expect("ok"),
-            )
-            .expect("replace");
+        let (outcome, _, _) = do_replace(&mut book, 1, 100, 3);
+        assert!(outcome.expect("replace").kept_priority);
         let mut ids = MockIds::new();
         let mut fills = Vec::new();
         let mut stp = stp_buf();
@@ -1561,6 +1646,137 @@ mod tests {
         assert_eq!(r.fills_count, 1);
         // FIFO preserved: id 1 (oldest) hit first.
         assert_eq!(fills[0].maker_order_id, OrderId::new(1).expect("ok"));
+    }
+
+    // Regression tests for issue #59: a lose-priority replace must
+    // re-run the matching walk, never rest a crossed book.
+
+    #[test]
+    fn test_replace_reprice_through_spread_trades_and_book_not_crossed() {
+        // Issue #59 repro: SELL 10@100 (acct 1) + BUY 10@99 (acct 2),
+        // then reprice the buy to 100 — through the spread. Must trade
+        // in full and leave the book flat, not rest 100/100 crossed.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 1, Side::Ask, 100, 10))
+            .expect("add");
+        book.add_resting(order_acct(2, 2, Side::Bid, 99, 10))
+            .expect("add");
+        let (outcome, fills, stp) = do_replace(&mut book, 2, 100, 10);
+        let outcome = outcome.expect("replace");
+        assert!(!outcome.kept_priority);
+        let result = outcome.match_result.expect("walk ran");
+        assert_eq!(result.fills_count, 1);
+        assert_eq!(result.taker_remaining, None);
+        assert!(stp.is_empty());
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].maker_order_id, OrderId::new(1).expect("ok"));
+        assert_eq!(fills[0].taker_order_id, OrderId::new(2).expect("ok"));
+        assert_eq!(fills[0].price, Price::new(100).expect("ok"));
+        assert_eq!(fills[0].qty, Qty::new(10).expect("ok"));
+        assert!(fills[0].maker_fully_filled);
+        // Book flat on both sides — never crossed.
+        assert_eq!(book.best_bid(), None);
+        assert_eq!(book.best_ask(), None);
+        assert_eq!(book.side_qty(Side::Bid), 0);
+        assert_eq!(book.side_qty(Side::Ask), 0);
+    }
+
+    #[test]
+    fn test_replace_reprice_partial_cross_rests_residual() {
+        // SELL 5@100 vs BUY 10@99 repriced to 100: 5 lots trade, the
+        // 5-lot residual rests as the new best bid at 100.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 1, Side::Ask, 100, 5))
+            .expect("add");
+        book.add_resting(order_acct(2, 2, Side::Bid, 99, 10))
+            .expect("add");
+        let (outcome, fills, _) = do_replace(&mut book, 2, 100, 10);
+        let result = outcome.expect("replace").match_result.expect("walk ran");
+        assert_eq!(result.fills_count, 1);
+        assert_eq!(result.taker_remaining, Some(Qty::new(5).expect("ok")));
+        assert_eq!(fills[0].qty, Qty::new(5).expect("ok"));
+        assert_eq!(book.best_ask(), None);
+        assert_eq!(book.best_bid(), Some(Price::new(100).expect("ok")));
+        assert_eq!(book.side_qty(Side::Bid), 5);
+    }
+
+    #[test]
+    fn test_replace_reprice_onto_own_order_stp_cancel_both() {
+        // Same account on both sides. Repricing the bid through the
+        // spread hits the account's own ask: cancel-both — no fill,
+        // maker dropped, taker not rested. Identical to a new order.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 7, Side::Ask, 100, 10))
+            .expect("add");
+        book.add_resting(order_acct(2, 7, Side::Bid, 99, 10))
+            .expect("add");
+        let (outcome, fills, stp) = do_replace(&mut book, 2, 100, 10);
+        let result = outcome.expect("replace").match_result.expect("walk ran");
+        assert!(result.taker_stp_cancelled);
+        assert!(fills.is_empty());
+        assert_eq!(stp.len(), 1);
+        assert_eq!(stp[0].order_id, OrderId::new(1).expect("ok"));
+        assert_eq!(book.best_bid(), None);
+        assert_eq!(book.best_ask(), None);
+    }
+
+    #[test]
+    fn test_replace_noncrossing_reprice_rests_no_fills() {
+        // Reprice away from the touch: pure cancel-and-re-add, no walk
+        // consequences observable.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 1, Side::Ask, 100, 10))
+            .expect("add");
+        book.add_resting(order_acct(2, 2, Side::Bid, 99, 10))
+            .expect("add");
+        let (outcome, fills, stp) = do_replace(&mut book, 2, 98, 10);
+        let result = outcome.expect("replace").match_result.expect("walk ran");
+        assert_eq!(result.fills_count, 0);
+        assert!(fills.is_empty());
+        assert!(stp.is_empty());
+        assert_eq!(book.best_bid(), Some(Price::new(98).expect("ok")));
+        assert_eq!(book.best_ask(), Some(Price::new(100).expect("ok")));
+        assert_eq!(book.side_qty(Side::Bid), 10);
+    }
+
+    #[test]
+    fn test_replace_postonly_would_cross_rejected_book_unchanged() {
+        // A resting PostOnly bid repriced through the spread keeps its
+        // never-take guarantee: the replace is rejected with zero book
+        // mutation and the original order stays resting.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 1, Side::Ask, 100, 10))
+            .expect("add");
+        book.add_resting(order_tif(2, 2, Side::Bid, 99, 10, Tif::PostOnly))
+            .expect("add");
+        let (outcome, fills, stp) = do_replace(&mut book, 2, 100, 10);
+        let result = outcome.expect("replace").match_result.expect("gate fired");
+        assert!(result.taker_post_only_rejected);
+        assert!(fills.is_empty());
+        assert!(stp.is_empty());
+        // Original order untouched at its old (price, qty).
+        assert_eq!(book.best_bid(), Some(Price::new(99).expect("ok")));
+        assert_eq!(book.best_ask(), Some(Price::new(100).expect("ok")));
+        assert_eq!(book.side_qty(Side::Bid), 10);
+        assert_eq!(book.side_qty(Side::Ask), 10);
+    }
+
+    #[test]
+    fn test_replace_postonly_noncrossing_reprice_rests() {
+        // A PostOnly reprice that does not cross behaves like any
+        // other lose-priority reprice: cancel + re-add, no fills.
+        let mut book = Book::new();
+        book.add_resting(order_acct(1, 1, Side::Ask, 100, 10))
+            .expect("add");
+        book.add_resting(order_tif(2, 2, Side::Bid, 99, 10, Tif::PostOnly))
+            .expect("add");
+        let (outcome, fills, _) = do_replace(&mut book, 2, 98, 10);
+        let result = outcome.expect("replace").match_result.expect("walk ran");
+        assert!(!result.taker_post_only_rejected);
+        assert_eq!(result.fills_count, 0);
+        assert!(fills.is_empty());
+        assert_eq!(book.best_bid(), Some(Price::new(98).expect("ok")));
+        assert_eq!(book.side_qty(Side::Bid), 10);
     }
 
     // -------------------------------------------------------------------

--- a/crates/matching/src/book.rs
+++ b/crates/matching/src/book.rs
@@ -28,6 +28,11 @@ struct OrderMeta {
     side: Side,
     price: Price,
     account_id: AccountId,
+    /// Time-in-force the order rested with. Read by the
+    /// cancel-replace path: a repriced `PostOnly` order keeps its
+    /// never-take guarantee (a would-cross reprice is rejected), so
+    /// the original TIF must survive the resting period.
+    tif: Tif,
 }
 
 /// A resting-order request handed to [`Book::add_resting`].
@@ -47,6 +52,10 @@ pub struct RestingOrder {
     pub price: Price,
     /// Order quantity.
     pub qty: Qty,
+    /// Time-in-force the order arrived with. `Ioc` never rests, so
+    /// only `Gtc` / `PostOnly` are meaningful here; the value is
+    /// stored in the sidecar and honored by [`Book::replace`].
+    pub tif: Tif,
 }
 
 /// Single-symbol order book.
@@ -105,6 +114,10 @@ impl Book {
         if self.index.contains_key(&order.order_id) {
             return Err(BookError::DuplicateOrderId);
         }
+        // `Ioc` is a taker-only policy — the engine cancels any IOC
+        // remainder instead of resting it, so an IOC here is a caller
+        // bug, not a reachable state.
+        debug_assert!(order.tif != Tif::Ioc, "IOC orders never rest");
         // Bump the arrival counter first so `TimestampMs` reflects the
         // post-add value rather than lagging by one. CLAUDE.md forbids
         // `wrapping_*` / `saturating_*` on protocol counters; surface
@@ -147,6 +160,7 @@ impl Book {
                 side: order.side,
                 price: order.price,
                 account_id: order.account_id,
+                tif: order.tif,
             },
         );
         self.by_account
@@ -534,6 +548,7 @@ impl Book {
                 side: meta.side,
                 price: new_price,
                 qty: new_qty,
+                tif: meta.tif,
             })?;
             Ok(ReplaceOutcome {
                 kept_priority: false,
@@ -736,6 +751,7 @@ mod tests {
             side,
             price: Price::new(price).expect("valid price fixture"),
             qty: Qty::new(qty).expect("valid qty fixture"),
+            tif: Tif::Gtc,
         }
     }
 
@@ -892,7 +908,8 @@ mod tests {
                 let added = book.add_resting(RestingOrder {
                     order_id: id,
                     account_id: AccountId::new(1).expect("ok"),
-                    side: *side, price: *price, qty: *qty
+                    side: *side, price: *price, qty: *qty,
+                    tif: Tif::Gtc,
                 });
                 if added.is_ok() {
                     ids.push(id);

--- a/crates/matching/src/fill.rs
+++ b/crates/matching/src/fill.rs
@@ -114,6 +114,13 @@ pub struct ReplaceOutcome {
     /// order was cancel-and-re-added at the new (price, qty) — any
     /// price change or qty-up loses priority.
     pub kept_priority: bool,
+    /// `Some` when the lose-priority path ran the matching walk (or
+    /// its `PostOnly` would-cross gate fired — signalled by
+    /// [`MatchResult::taker_post_only_rejected`] with zero book
+    /// mutation). `None` on the kept-priority in-place path: a
+    /// same-price qty-down was already resting without crossing, so
+    /// no walk is needed.
+    pub match_result: Option<MatchResult>,
 }
 
 /// Summary of one [`crate::Book::match_aggressive`] call.

--- a/crates/matching/tests/invariants.rs
+++ b/crates/matching/tests/invariants.rs
@@ -2,7 +2,7 @@
 //! Ensures that the matching engine preserves critical invariants under all valid sequences
 //! of add, cancel, and match operations.
 
-use domain::{AccountId, OrderId, Price, Qty, Side};
+use domain::{AccountId, OrderId, Price, Qty, Side, Tif};
 use matching::{Book, RestingOrder};
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -81,6 +81,7 @@ fn apply_commands(book: &mut Book, commands: &[Command]) -> (HashMap<u64, OrderE
                         side: *side,
                         price: p,
                         qty: q,
+                        tif: Tif::Gtc,
                     };
                     if book.add_resting(resting).is_ok() {
                         order_map.insert(*order_id, (*side, p, q, acc_id));

--- a/crates/matching/tests/props_book_not_crossed.proptest-regressions
+++ b/crates/matching/tests/props_book_not_crossed.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4d736c015cfa55ca516dff7ceaeff3c53133ad4863db917347f6301512018bcf # shrinks to commands = [NewOrder { order_id: 32, account_id: 1, side: Bid, price: 90, qty: 1, tif: Gtc }, NewOrder { order_id: 1, account_id: 1, side: Bid, price: 90, qty: 1, tif: Gtc }, NewOrder { order_id: 2, account_id: 1, side: Ask, price: 91, qty: 1, tif: Gtc }, Replace { order_id: 32, new_price: 91, new_qty: 1 }]

--- a/crates/matching/tests/props_book_not_crossed.rs
+++ b/crates/matching/tests/props_book_not_crossed.rs
@@ -1,0 +1,205 @@
+//! Property: the book is never crossed (`best_bid < best_ask`
+//! whenever both sides are non-empty) after any valid sequence of
+//! new-order / cancel / replace operations.
+//!
+//! Regression coverage for issue #59: `Book::replace`'s lose-priority
+//! path rested the new (price, qty) without re-running the matching
+//! walk, so a reprice through the spread left `best_bid >= best_ask`.
+//!
+//! The command driver mirrors the engine pipeline's use of the book:
+//! a new order goes through `match_aggressive` and only the
+//! non-crossing residual rests; cancel and replace hit the public
+//! `Book` API directly.
+
+use domain::{AccountId, EngineSeq, IdGenerator, OrderId, Price, Qty, Side, Tif, TradeId};
+use matching::{AggressiveOrder, Book, Fill, RestingOrder, StpCancellation};
+use proptest::prelude::*;
+
+/// Deterministic monotonic id source for the fill loop. Matching
+/// tests cannot use `engine::CounterIdGenerator` (that would invert
+/// the crate dependency), so a local stub implements the same
+/// contract.
+struct TestIds {
+    trade: u64,
+    seq: u64,
+}
+
+impl TestIds {
+    fn new() -> Self {
+        Self { trade: 0, seq: 0 }
+    }
+}
+
+impl IdGenerator for TestIds {
+    fn next_trade_id(&mut self) -> TradeId {
+        self.trade += 1;
+        TradeId::new(self.trade)
+    }
+
+    fn next_engine_seq(&mut self) -> EngineSeq {
+        self.seq += 1;
+        EngineSeq::new(self.seq)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Command {
+    NewOrder {
+        order_id: u64,
+        account_id: u32,
+        side: Side,
+        price: i64,
+        qty: u64,
+        tif: Tif,
+    },
+    Cancel {
+        order_id: u64,
+    },
+    Replace {
+        order_id: u64,
+        new_price: i64,
+        new_qty: u64,
+    },
+}
+
+/// Small id space so cancels / replaces hit live orders often; tight
+/// price band so reprices cross the touch often. Uniform prices over
+/// a wide range would leave the interesting paths cold.
+fn arb_command() -> impl Strategy<Value = Command> {
+    let arb_tif = prop_oneof![
+        6 => Just(Tif::Gtc),
+        2 => Just(Tif::PostOnly),
+        1 => Just(Tif::Ioc),
+    ];
+    prop_oneof![
+        6 => (
+            1u64..60u64,
+            1u32..5u32,
+            prop_oneof![Just(Side::Bid), Just(Side::Ask)],
+            90i64..=110i64,
+            1u64..=20u64,
+            arb_tif,
+        )
+            .prop_map(|(order_id, account_id, side, price, qty, tif)| {
+                Command::NewOrder { order_id, account_id, side, price, qty, tif }
+            }),
+        2 => (1u64..60u64).prop_map(|order_id| Command::Cancel { order_id }),
+        3 => (1u64..60u64, 90i64..=110i64, 1u64..=20u64).prop_map(
+            |(order_id, new_price, new_qty)| Command::Replace { order_id, new_price, new_qty }
+        ),
+    ]
+}
+
+/// Mirror of `engine::handle_new_order`'s book interaction: run the
+/// matching walk, then rest the residual only when the order
+/// survived (no STP, no post-only reject, TIF rests).
+#[allow(clippy::too_many_arguments)]
+fn apply_new_order(
+    book: &mut Book,
+    ids: &mut TestIds,
+    fills: &mut Vec<Fill>,
+    stp: &mut Vec<StpCancellation>,
+    order_id: u64,
+    account_id: u32,
+    side: Side,
+    price: i64,
+    qty: u64,
+    tif: Tif,
+) {
+    let (Ok(order_id), Ok(account_id), Ok(price), Ok(qty)) = (
+        OrderId::new(order_id),
+        AccountId::new(account_id),
+        Price::new(price),
+        Qty::new(qty),
+    ) else {
+        return;
+    };
+    // NOTE: the engine rejects duplicate live order ids before the
+    // walk; this driver instead lets `add_resting` fail on the
+    // duplicate below. The walk still runs, which is harmless for
+    // this invariant — matching can only uncross, never cross.
+    let result = book.match_aggressive(
+        AggressiveOrder {
+            order_id,
+            account_id,
+            side,
+            price: Some(price),
+            qty,
+            tif,
+        },
+        ids,
+        fills,
+        stp,
+    );
+    if result.taker_stp_cancelled || result.taker_post_only_rejected || tif == Tif::Ioc {
+        return;
+    }
+    if let Some(remaining) = result.taker_remaining {
+        let _ = book.add_resting(RestingOrder {
+            order_id,
+            account_id,
+            side,
+            price,
+            qty: remaining,
+            tif,
+        });
+    }
+}
+
+fn assert_not_crossed(book: &Book) -> Result<(), TestCaseError> {
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        prop_assert!(
+            bid < ask,
+            "book crossed: best_bid={} best_ask={}",
+            bid.as_ticks(),
+            ask.as_ticks()
+        );
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn book_never_crossed_across_add_cancel_replace(
+        commands in prop::collection::vec(arb_command(), 1..200)
+    ) {
+        let mut book = Book::new();
+        let mut ids = TestIds::new();
+        let mut fills = Vec::new();
+        let mut stp = Vec::new();
+
+        for cmd in &commands {
+            match cmd {
+                Command::NewOrder { order_id, account_id, side, price, qty, tif } => {
+                    apply_new_order(
+                        &mut book, &mut ids, &mut fills, &mut stp,
+                        *order_id, *account_id, *side, *price, *qty, *tif,
+                    );
+                }
+                Command::Cancel { order_id } => {
+                    if let Ok(oid) = OrderId::new(*order_id) {
+                        let _ = book.cancel(oid);
+                    }
+                }
+                Command::Replace { order_id, new_price, new_qty } => {
+                    if let (Ok(oid), Ok(p), Ok(q)) = (
+                        OrderId::new(*order_id),
+                        Price::new(*new_price),
+                        Qty::new(*new_qty),
+                    ) {
+                        let _ = book.replace(oid, p, q, &mut ids, &mut fills, &mut stp);
+                    }
+                }
+            }
+            // The invariant must hold after EVERY operation, not just
+            // at the end — a transiently crossed book is still a bug.
+            assert_not_crossed(&book)?;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Book::replace`'s lose-priority path cancelled and re-added the new
`(price, qty)` without re-running the matching walk, so a cancel-replace
repricing through the spread rested a **crossed book** (`best_bid ==
best_ask`, full qty on both sides, zero trades) — reported in #59 with a
verified repro. The lose-priority path now re-submits the repriced order
through `match_aggressive` (NASDAQ OUCH / CME iLink semantics: a marketable
modify executes) and rests only the non-crossing residual; the engine
pipeline emits the resulting fills and keeps risk state consistent.

## Changes

- **Matching**: the lose-priority replace runs the same aggressive walk as a
  brand-new order, under the order's stored TIF. Fills / STP records land in
  the caller's scratch buffers; only the residual rests. The order keeps its
  original `order_id` through fills.
- **TIF is now stored in the book sidecar** (`OrderMeta` / `RestingOrder`):
  a resting `PostOnly` order repriced to a would-cross price is rejected
  with `PostOnlyWouldCross` and zero book mutation, preserving its
  never-take guarantee.
- **STP on replace**: a reprice onto the account's own resting order fires
  cancel-both, identical to a new order at that level — nothing rests.
- **Engine emission**: `Replaced` ack is emitted first (OUCH-style) and is
  non-terminal (`leaves_qty = new_qty`); trade prints and maker/taker fill
  reports follow and decrement it. Fill/STP emission plus maker risk
  book-keeping are factored out of `handle_new_order` into shared helpers
  and reused verbatim.
- **Risk**: only the resting residual's notional is charged (not the full
  new qty). On a cap reject the residual cancels while fills stand — trades
  are unrollbackable.
- **Ownership gate**: a cancel-replace from a non-owning account is rejected
  as `UnknownOrderId` (no cross-account order-id leak). The same gap on the
  plain cancel path is tracked as a follow-up issue.
- Side fix: `u64::is_multiple_of` (stable 1.87) replaced with plain modulo
  in engine bins/benches/tests — `clippy::incompatible_msrv` had broken the
  gate and main's CI after the MSRV was set to 1.86.

## Technical decisions

- **Re-match vs reject-on-cross**: re-matching matches `doc/DESIGN.md`
  § CancelReplace ("posible match") and venue precedent (OUCH Replace
  executes if marketable; iLink 35=G trades on a marketable modify).
  Reject-on-cross is reserved for `PostOnly` orders, which now carry their
  TIF through the sidecar.
- **Report sequence**: `Replaced` first, then fills. The ack is
  deliberately non-terminal (`leaves_qty = new_qty`; `cancel_reason:
  Replaced` marks the end of the old (price, qty) incarnation, not of the
  order). The known asymmetry with `handle_new_order` (fills first, then
  `Accepted`) is documented in the README; unifying would change the golden
  fixture — follow-up.
- **Risk-cap ordering**: charging the post-walk residual avoids
  false-rejecting marketable, exposure-reducing replaces that a worst-case
  pre-charge would block.

## Public API impact

- `matching::Book::replace` is now generic over `IdGenerator` and takes
  `ids`, `out_fills`, `out_stp` (same contract as `match_aggressive`).
- `matching::ReplaceOutcome` gains `match_result: Option<MatchResult>`.
- `matching::RestingOrder` gains `tif: Tif`.
- README (§ Cancel-replace, § STP, § Locked/crossed) updated; rustdoc on
  `Book::replace` / `ReplaceOutcome` rewritten.

## Determinism

Byte-identical replay holds (`--no-timestamps` per CLAUDE.md).
`fixtures/outbound.golden` untouched — the fixture generator and the
`replay_equality` proptest are NewOrder-only, and the shared emission
helpers are a behavior-preserving refactor of the new-order path.
`determinism-auditor`: Replay safe: yes / Commit safe: yes, zero findings.

## Testing

- [x] Unit tests added or updated (issue repro, partial cross, STP
      cancel-both, non-crossing reprice, both PostOnly cases, ownership)
- [x] Property-based (`proptest`) coverage for any new or changed matching
      invariant (`book_not_crossed`, validated to fail against the pre-fix
      code)
- [x] Replay determinism test still green (golden diff byte-identical)
- [x] `determinism-auditor` + `hotpath-reviewer` run clean
- [x] `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings
      && cargo nextest run` run locally and clean (254 passed / 0 failed)

## Checklist

- [x] Code follows `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Integer-only prices and quantities in `crates/domain` and `crates/matching`; no `f32` / `f64`
- [x] No wall-clock reads in `crates/matching/` (timestamps via `Clock` trait)
- [x] No `HashMap` / `HashSet` / `DashMap` iteration reaches outbound messages (sorted index only)
- [x] Checked arithmetic on `engine_seq` — no `saturating_*` / `wrapping_*`
- [x] Module boundaries respected (matching / risk / domain depend downward only; tokio stays in gateway)
- [x] No new dependencies added
- [x] Matching core has no logging
- [x] README updated (cancel-replace semantics, STP on replace, crossed-book invariant)

Closes #59
