### PR TITLE
Reject cancel from a non-owning account (#61)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -482,6 +482,26 @@ impl<C: Clock, I: IdGenerator, S: OutboundSink> Engine<C, I, S> {
             // Book updates emitted in `step` after the handler returns.
             return;
         }
+        // Ownership gate: only the owning account may cancel the
+        // order (mirrors the cancel-replace gate from #59/#60). The
+        // registry mirrors the book 1:1 in the single-writer
+        // pipeline, so the engine-level check suffices — Book::cancel
+        // keeps its requester-less signature because the matching
+        // core also cancels on the engine's own authority (fills,
+        // STP, mass-cancel). Report UnknownOrderId rather than a
+        // dedicated reason so foreign order ids do not leak across
+        // accounts.
+        if let Some(entry) = self.registry.get(&msg.order_id)
+            && entry.account_id != msg.account_id
+        {
+            self.emit_rejected(
+                msg.order_id,
+                msg.account_id,
+                RejectReason::UnknownOrderId,
+                recv_ts,
+            );
+            return;
+        }
         if self.book.cancel(msg.order_id).is_ok() {
             if let Some(entry) = self.registry.remove(&msg.order_id) {
                 self.risk.on_order_removed(entry.account_id, entry.notional);

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -385,6 +385,90 @@ fn engine_inner_sink(engine: &mut Engine<StubClock, CounterIdGenerator, VecSink>
 }
 
 // ---------------------------------------------------------------------
+// Cancel ownership (issue #61)
+// ---------------------------------------------------------------------
+
+#[test]
+fn cancel_from_non_owner_is_rejected_book_unchanged() {
+    use domain::{CancelReason, ExecState, RejectReason};
+    use wire::inbound::CancelOrder;
+
+    let mut engine = Engine::new(
+        StubClock::new(1_000_000_000),
+        CounterIdGenerator::new(),
+        VecSink::new(),
+    );
+    engine.step(Inbound::NewOrder(limit_order(1, 7, Side::Bid, 100, 5)));
+    let _ = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    // Account 9 tries to cancel account 7's order. Must reject (as
+    // UnknownOrderId — no cross-account id leak) with zero mutation.
+    engine.step(Inbound::CancelOrder(CancelOrder {
+        client_ts: ClientTs::new(0),
+        order_id: OrderId::new(1).expect("ok"),
+        account_id: AccountId::new(9).expect("ok"),
+    }));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+
+    let rejects: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) if r.state == ExecState::Rejected => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejects.len(), 1);
+    assert_eq!(rejects[0].reject_reason, Some(RejectReason::UnknownOrderId));
+    assert!(
+        !events
+            .iter()
+            .any(|o| matches!(o, Outbound::ExecReport(r) if r.state == ExecState::Cancelled)),
+        "foreign cancel must not cancel"
+    );
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    assert_eq!(
+        top.bid.map(|(p, q)| (p.as_ticks(), q.as_lots())),
+        Some((100, 5))
+    );
+
+    // Regression: the owning account can still cancel.
+    engine.step(Inbound::CancelOrder(CancelOrder {
+        client_ts: ClientTs::new(0),
+        order_id: OrderId::new(1).expect("ok"),
+        account_id: AccountId::new(7).expect("ok"),
+    }));
+    let events = std::mem::take(&mut engine_inner_sink(&mut engine).events);
+    let cancelled: Vec<_> = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::ExecReport(r) if r.state == ExecState::Cancelled => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(
+        cancelled[0].cancel_reason,
+        Some(CancelReason::UserRequested)
+    );
+    let top = events
+        .iter()
+        .filter_map(|o| match o {
+            Outbound::BookUpdateTop(b) => Some(b),
+            _ => None,
+        })
+        .next_back()
+        .expect("top-of-book emitted");
+    assert_eq!(top.bid, None);
+}
+
+// ---------------------------------------------------------------------
 // Cancel-replace re-match (issue #59)
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`handle_cancel_order` never compared the requester's `account_id` against
the resting order's owner, so any session-bound account could cancel
another account's order by guessing its client-assigned id — an
unauthorized book mutation and an order-id oracle. PR #60 closed the same
gap on the cancel-replace path; this PR mirrors that gate onto the plain
cancel path (#61).

## Changes

- Ownership gate in `handle_cancel_order`: one registry point lookup before
  `book.cancel`; on account mismatch the cancel is rejected as
  `UnknownOrderId` — same policy and reason code as the #60 replace gate,
  so foreign order ids do not leak across accounts.
- `Book::cancel` keeps its requester-less signature: the registry mirrors
  the book 1:1 in the single-writer pipeline, and the matching core also
  cancels on the engine's own authority (fills, STP, mass-cancel) where no
  requester exists. This decision is documented in the code comment, per
  the issue's task list.
- Integration test: foreign cancel rejected with zero book mutation, then
  the owning account's cancel still succeeds (`Cancelled{UserRequested}`,
  book empty).

## Determinism

Byte-identical replay holds. The golden fixture contains one same-owner
`CancelOrder` (order 3, account 2), for which the gate is a no-op —
verified empirically: replay of `fixtures/inbound.bin` diffs byte-identical
against `fixtures/outbound.golden` (`--no-timestamps`). No golden
regeneration. `determinism-auditor`: Replay safe: yes / Commit safe: yes,
zero findings. `hotpath-reviewer`: OK to commit (one P3 note: the gate's
`get` plus the pre-existing `remove` double-probe the registry on the
happy path — flagged for attention only if it ever shows in the p99.9
cancel histogram).

## Testing

- [x] Unit/integration tests added (foreign cancel rejected + owner cancel
      regression, same commit as the fix)
- [x] Replay determinism test still green (golden diff byte-identical)
- [x] `determinism-auditor` + `hotpath-reviewer` run clean
- [x] `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings
      && cargo nextest run` run locally and clean (255 passed / 0 failed)

## Checklist

- [x] Code follows `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `HashMap` / `HashSet` / `DashMap` iteration reaches outbound messages (point lookup only)
- [x] Module boundaries respected (engine-level gate; matching core untouched)
- [x] No new dependencies added

Closes #61
